### PR TITLE
feat: 記事 CRUD API を実装 (#6)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
 	"files": {
-		"includes": ["**", "!**/.astro"]
+		"includes": ["**", "!**/.astro", "!**/dist", "!**/node_modules"]
 	},
 	"assist": {
 		"actions": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"astro": "astro",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
-		"db:studio": "drizzle-kit studio"
+		"db:studio": "drizzle-kit studio",
+		"db:seed": "tsx src/db/seed.ts"
 	},
 	"dependencies": {
 		"astro": "^5.17.1",
@@ -28,6 +29,7 @@
 		"@biomejs/biome": "^2.4.4",
 		"wrangler": "^4.14.0",
 		"drizzle-kit": "^0.31.9",
+		"tsx": "^4.19.0",
 		"typescript": "^5.7.3"
 	},
 	"pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       astro:
         specifier: ^5.17.1
-        version: 5.18.0(@types/node@22.19.13)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 5.18.0(@types/node@22.19.13)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@cloudflare/workers-types@4.20260301.1)(@neondatabase/serverless@1.0.2)(@types/pg@8.18.0)(postgres@3.4.8)
@@ -23,13 +23,16 @@ importers:
         version: 0.9.6(prettier@3.8.1)(typescript@5.9.3)
       '@astrojs/cloudflare':
         specifier: ^12.6.12
-        version: 12.6.12(@types/node@22.19.13)(astro@5.18.0(@types/node@22.19.13)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))(yaml@2.8.2)
+        version: 12.6.12(@types/node@22.19.13)(astro@5.18.0(@types/node@22.19.13)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(tsx@4.21.0)(yaml@2.8.2)
       '@biomejs/biome':
         specifier: ^2.4.4
         version: 2.4.5
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -2370,6 +2373,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -2778,14 +2786,14 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@12.6.12(@types/node@22.19.13)(astro@5.18.0(@types/node@22.19.13)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))(yaml@2.8.2)':
+  '@astrojs/cloudflare@12.6.12(@types/node@22.19.13)(astro@5.18.0(@types/node@22.19.13)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(tsx@4.21.0)(yaml@2.8.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.7.5
       '@astrojs/underscore-redirects': 1.0.0
       '@cloudflare/workers-types': 4.20260301.1
-      astro: 5.18.0(@types/node@22.19.13)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 5.18.0(@types/node@22.19.13)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tinyglobby: 0.2.15
-      vite: 6.4.1(@types/node@22.19.13)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.13)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.50.0(@cloudflare/workers-types@4.20260301.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -3748,7 +3756,7 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
-  astro@5.18.0(@types/node@22.19.13)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@5.18.0(@types/node@22.19.13)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.5
@@ -3805,8 +3813,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@22.19.13)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.13)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@22.19.13)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.13)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -5130,6 +5138,13 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-fest@4.41.0: {}
 
   typesafe-path@0.2.2: {}
@@ -5239,7 +5254,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@22.19.13)(yaml@2.8.2):
+  vite@6.4.1(@types/node@22.19.13)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5250,11 +5265,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
       fsevents: 2.3.3
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@22.19.13)(yaml@2.8.2)):
+  vitefu@1.1.2(vite@6.4.1(@types/node@22.19.13)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.13)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.13)(tsx@4.21.0)(yaml@2.8.2)
 
   volar-service-css@0.0.68(@volar/language-service@2.4.28):
     dependencies:

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,0 +1,32 @@
+import { createDb } from './index';
+import { tags } from './schema';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) throw new Error('DATABASE_URL is required');
+
+const db = createDb(DATABASE_URL);
+
+async function seed() {
+	console.log('Seeding tags...');
+	await db
+		.insert(tags)
+		.values([
+			{ name: 'レイド', slug: 'raid', category: 'duty' },
+			{ name: '討滅戦', slug: 'trial', category: 'duty' },
+			{ name: 'ダンジョン', slug: 'dungeon', category: 'duty' },
+			{ name: 'タンク', slug: 'tank', category: 'job' },
+			{ name: 'ヒーラー', slug: 'healer', category: 'job' },
+			{ name: 'DPS', slug: 'dps', category: 'job' },
+			{ name: 'クラフター', slug: 'crafter', category: 'crafting' },
+			{ name: 'ギャザラー', slug: 'gatherer', category: 'gathering' },
+			{ name: '初心者向け', slug: 'beginner', category: 'general' },
+			{ name: '金策', slug: 'gil-making', category: 'general' },
+			{ name: 'ハウジング', slug: 'housing', category: 'general' },
+			{ name: 'ミラプリ', slug: 'glamour', category: 'general' },
+		])
+		.onConflictDoNothing();
+	console.log('Done!');
+	process.exit(0);
+}
+
+seed();

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="../.astro/types.d.ts" />
+
 type Env = {
 	DATABASE_URL: string;
 	DISCORD_CLIENT_ID: string;
@@ -6,3 +8,12 @@ type Env = {
 	SESSION_SECRET: string;
 	R2_BUCKET: R2Bucket;
 };
+
+type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
+
+declare namespace App {
+	interface Locals extends Runtime {
+		db: import('./db').Database;
+		currentUser: import('./lib/auth').AuthUser | null;
+	}
+}

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -1,0 +1,282 @@
+import { and, count, desc, eq, inArray } from 'drizzle-orm';
+import type { Database } from '../db';
+import { articles, articleTags, tags, users } from '../db/schema';
+import { generateSlug } from './slug';
+
+export interface ListArticlesOptions {
+	page?: number;
+	limit?: number;
+	tag?: string;
+	status?: 'draft' | 'published' | 'archived';
+}
+
+export interface CreateArticleData {
+	title: string;
+	body: string;
+	tags?: string[];
+	status?: 'draft' | 'published';
+}
+
+export interface UpdateArticleData {
+	title?: string;
+	body?: string;
+	tags?: string[];
+	status?: 'draft' | 'published';
+}
+
+interface AuthorInfo {
+	id: string;
+	username: string;
+	displayName: string;
+	avatarUrl: string | null;
+}
+
+interface TagInfo {
+	id: string;
+	name: string;
+	slug: string;
+	category: string;
+}
+
+interface ArticleDetail {
+	id: string;
+	title: string;
+	slug: string;
+	body: string;
+	status: string;
+	publishedAt: Date | null;
+	createdAt: Date;
+	updatedAt: Date;
+	author: AuthorInfo;
+	tags: TagInfo[];
+}
+
+async function getTagsForArticles(
+	db: Database,
+	articleIds: string[],
+): Promise<Map<string, TagInfo[]>> {
+	if (articleIds.length === 0) return new Map();
+
+	const rows = await db
+		.select({
+			articleId: articleTags.articleId,
+			id: tags.id,
+			name: tags.name,
+			slug: tags.slug,
+			category: tags.category,
+		})
+		.from(articleTags)
+		.innerJoin(tags, eq(articleTags.tagId, tags.id))
+		.where(inArray(articleTags.articleId, articleIds));
+
+	const map = new Map<string, TagInfo[]>();
+	for (const row of rows) {
+		const list = map.get(row.articleId) ?? [];
+		list.push({
+			id: row.id,
+			name: row.name,
+			slug: row.slug,
+			category: row.category,
+		});
+		map.set(row.articleId, list);
+	}
+	return map;
+}
+
+export async function listArticles(db: Database, options: ListArticlesOptions = {}) {
+	const page = Math.max(1, options.page ?? 1);
+	const limit = Math.min(100, Math.max(1, options.limit ?? 20));
+	const offset = (page - 1) * limit;
+	const status = (options.status ?? 'published') as 'draft' | 'published' | 'archived';
+
+	const conditions = [eq(articles.status, status)];
+
+	if (options.tag) {
+		const tagRow = await db
+			.select({ id: tags.id })
+			.from(tags)
+			.where(eq(tags.slug, options.tag))
+			.limit(1);
+
+		if (tagRow.length > 0) {
+			const articleIdsWithTag = db
+				.select({ articleId: articleTags.articleId })
+				.from(articleTags)
+				.where(eq(articleTags.tagId, tagRow[0].id));
+			conditions.push(inArray(articles.id, articleIdsWithTag));
+		} else {
+			return { data: [], meta: { page, limit, total: 0 } };
+		}
+	}
+
+	const where = and(...conditions);
+
+	const [totalResult, rows] = await Promise.all([
+		db.select({ total: count() }).from(articles).where(where),
+		db
+			.select({
+				id: articles.id,
+				title: articles.title,
+				slug: articles.slug,
+				body: articles.body,
+				status: articles.status,
+				publishedAt: articles.publishedAt,
+				createdAt: articles.createdAt,
+				updatedAt: articles.updatedAt,
+				authorId: users.id,
+				authorUsername: users.username,
+				authorDisplayName: users.displayName,
+				authorAvatarUrl: users.avatarUrl,
+			})
+			.from(articles)
+			.leftJoin(users, eq(articles.authorId, users.id))
+			.where(where)
+			.orderBy(desc(articles.createdAt))
+			.limit(limit)
+			.offset(offset),
+	]);
+
+	const total = totalResult[0]?.total ?? 0;
+	const articleIds = rows.map((r) => r.id);
+	const tagsMap = await getTagsForArticles(db, articleIds);
+
+	const data: ArticleDetail[] = rows.map((row) => ({
+		id: row.id,
+		title: row.title,
+		slug: row.slug,
+		body: row.body,
+		status: row.status,
+		publishedAt: row.publishedAt,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		author: {
+			id: row.authorId as string,
+			username: row.authorUsername as string,
+			displayName: row.authorDisplayName as string,
+			avatarUrl: row.authorAvatarUrl ?? null,
+		},
+		tags: tagsMap.get(row.id) ?? [],
+	}));
+
+	return { data, meta: { page, limit, total } };
+}
+
+export async function getArticleBySlug(db: Database, slug: string): Promise<ArticleDetail | null> {
+	const rows = await db
+		.select({
+			id: articles.id,
+			title: articles.title,
+			slug: articles.slug,
+			body: articles.body,
+			status: articles.status,
+			publishedAt: articles.publishedAt,
+			createdAt: articles.createdAt,
+			updatedAt: articles.updatedAt,
+			authorId: users.id,
+			authorUsername: users.username,
+			authorDisplayName: users.displayName,
+			authorAvatarUrl: users.avatarUrl,
+		})
+		.from(articles)
+		.leftJoin(users, eq(articles.authorId, users.id))
+		.where(eq(articles.slug, slug))
+		.limit(1);
+
+	if (rows.length === 0) return null;
+
+	const row = rows[0];
+	const tagsMap = await getTagsForArticles(db, [row.id]);
+
+	return {
+		id: row.id,
+		title: row.title,
+		slug: row.slug,
+		body: row.body,
+		status: row.status,
+		publishedAt: row.publishedAt,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		author: {
+			id: row.authorId as string,
+			username: row.authorUsername as string,
+			displayName: row.authorDisplayName as string,
+			avatarUrl: row.authorAvatarUrl ?? null,
+		},
+		tags: tagsMap.get(row.id) ?? [],
+	};
+}
+
+export async function createArticle(
+	db: Database,
+	data: CreateArticleData,
+	authorId: string,
+): Promise<ArticleDetail> {
+	const slug = generateSlug();
+	const status = data.status ?? 'draft';
+	const now = new Date();
+
+	const [inserted] = await db
+		.insert(articles)
+		.values({
+			title: data.title,
+			slug,
+			body: data.body,
+			authorId,
+			status,
+			publishedAt: status === 'published' ? now : null,
+		})
+		.returning({ id: articles.id, slug: articles.slug });
+
+	if (data.tags && data.tags.length > 0) {
+		await db
+			.insert(articleTags)
+			.values(data.tags.map((tagId) => ({ articleId: inserted.id, tagId })));
+	}
+
+	return (await getArticleBySlug(db, inserted.slug)) as ArticleDetail;
+}
+
+export async function updateArticle(
+	db: Database,
+	articleId: string,
+	data: UpdateArticleData,
+): Promise<ArticleDetail | null> {
+	const existing = await db
+		.select({ publishedAt: articles.publishedAt, slug: articles.slug })
+		.from(articles)
+		.where(eq(articles.id, articleId))
+		.limit(1);
+
+	if (existing.length === 0) return null;
+
+	const updates: Record<string, unknown> = { updatedAt: new Date() };
+	if (data.title !== undefined) updates.title = data.title;
+	if (data.body !== undefined) updates.body = data.body;
+	if (data.status !== undefined) {
+		updates.status = data.status;
+		if (data.status === 'published' && existing[0].publishedAt === null) {
+			updates.publishedAt = new Date();
+		}
+	}
+
+	await db.update(articles).set(updates).where(eq(articles.id, articleId));
+
+	if (data.tags !== undefined) {
+		await db.delete(articleTags).where(eq(articleTags.articleId, articleId));
+		if (data.tags.length > 0) {
+			await db.insert(articleTags).values(data.tags.map((tagId) => ({ articleId, tagId })));
+		}
+	}
+
+	const [updated] = await db
+		.select({ slug: articles.slug })
+		.from(articles)
+		.where(eq(articles.id, articleId))
+		.limit(1);
+
+	return getArticleBySlug(db, updated.slug);
+}
+
+export async function deleteArticle(db: Database, articleId: string): Promise<void> {
+	await db.delete(articles).where(eq(articles.id, articleId));
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,33 @@
+import { eq } from 'drizzle-orm';
+import type { Database } from '../db';
+import { users } from '../db/schema';
+
+export interface AuthUser {
+	id: string;
+	username: string;
+	displayName: string;
+	avatarUrl: string | null;
+	role: 'user' | 'moderator' | 'admin';
+}
+
+export async function resolveUser(request: Request, db: Database): Promise<AuthUser | null> {
+	const header = request.headers.get('Authorization');
+	if (!header?.startsWith('Bearer ')) return null;
+
+	const userId = header.slice(7).trim();
+	if (!userId) return null;
+
+	const [user] = await db
+		.select({
+			id: users.id,
+			username: users.username,
+			displayName: users.displayName,
+			avatarUrl: users.avatarUrl,
+			role: users.role,
+		})
+		.from(users)
+		.where(eq(users.id, userId))
+		.limit(1);
+
+	return (user as AuthUser) ?? null;
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,39 @@
+type ErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'UNAUTHORIZED' | 'FORBIDDEN' | 'INTERNAL_ERROR';
+
+interface ErrorBody {
+	error: {
+		code: ErrorCode;
+		message: string;
+		details?: Record<string, string[]>;
+	};
+}
+
+export function errorResponse(
+	status: number,
+	code: ErrorCode,
+	message: string,
+	details?: Record<string, string[]>,
+): Response {
+	const body: ErrorBody = { error: { code, message } };
+	if (details) body.error.details = details;
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export function validationError(details: Record<string, string[]>): Response {
+	return errorResponse(400, 'VALIDATION_ERROR', 'Validation failed', details);
+}
+
+export function notFound(message = 'Resource not found'): Response {
+	return errorResponse(404, 'NOT_FOUND', message);
+}
+
+export function unauthorized(message = 'Authentication required'): Response {
+	return errorResponse(401, 'UNAUTHORIZED', message);
+}
+
+export function forbidden(message = 'Permission denied'): Response {
+	return errorResponse(403, 'FORBIDDEN', message);
+}

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,9 @@
+export function generateSlug(): string {
+	const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+	const bytes = crypto.getRandomValues(new Uint8Array(8));
+	let result = 'article-';
+	for (const byte of bytes) {
+		result += chars[byte % chars.length];
+	}
+	return result;
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,145 @@
+type ValidationSuccess<T> = { success: true; data: T };
+type ValidationFailure = { success: false; errors: Record<string, string[]> };
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+export interface CreateArticleInput {
+	title: string;
+	body: string;
+	tags?: string[];
+	status?: 'draft' | 'published';
+}
+
+export interface UpdateArticleInput {
+	title?: string;
+	body?: string;
+	tags?: string[];
+	status?: 'draft' | 'published';
+}
+
+export function validateCreateArticle(data: unknown): ValidationResult<CreateArticleInput> {
+	if (typeof data !== 'object' || data === null) {
+		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
+	}
+
+	const obj = data as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	// title
+	if (obj.title === undefined || obj.title === null) {
+		errors.title = ['title is required'];
+	} else if (typeof obj.title !== 'string') {
+		errors.title = ['title must be a string'];
+	} else if (obj.title.length < 1 || obj.title.length > 100) {
+		errors.title = ['title must be between 1 and 100 characters'];
+	}
+
+	// body
+	if (obj.body === undefined || obj.body === null) {
+		errors.body = ['body is required'];
+	} else if (typeof obj.body !== 'string') {
+		errors.body = ['body must be a string'];
+	} else if (obj.body.length < 1 || obj.body.length > 50000) {
+		errors.body = ['body must be between 1 and 50000 characters'];
+	}
+
+	// tags (optional)
+	if (obj.tags !== undefined) {
+		if (!Array.isArray(obj.tags)) {
+			errors.tags = ['tags must be an array'];
+		} else if (obj.tags.length > 10) {
+			errors.tags = ['tags must have at most 10 items'];
+		} else if (!obj.tags.every((t: unknown) => typeof t === 'string')) {
+			errors.tags = ['each tag must be a string'];
+		}
+	}
+
+	// status (optional)
+	if (obj.status !== undefined) {
+		if (obj.status !== 'draft' && obj.status !== 'published') {
+			errors.status = ['status must be "draft" or "published"'];
+		}
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { success: false, errors };
+	}
+
+	return {
+		success: true,
+		data: {
+			title: obj.title as string,
+			body: obj.body as string,
+			tags: obj.tags as string[] | undefined,
+			status: (obj.status as 'draft' | 'published') ?? undefined,
+		},
+	};
+}
+
+export function validateUpdateArticle(data: unknown): ValidationResult<UpdateArticleInput> {
+	if (typeof data !== 'object' || data === null) {
+		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
+	}
+
+	const obj = data as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	const hasTitle = obj.title !== undefined;
+	const hasBody = obj.body !== undefined;
+	const hasTags = obj.tags !== undefined;
+	const hasStatus = obj.status !== undefined;
+
+	if (!hasTitle && !hasBody && !hasTags && !hasStatus) {
+		return {
+			success: false,
+			errors: { _: ['At least one field must be provided'] },
+		};
+	}
+
+	// title (optional)
+	if (hasTitle) {
+		if (typeof obj.title !== 'string') {
+			errors.title = ['title must be a string'];
+		} else if (obj.title.length < 1 || obj.title.length > 100) {
+			errors.title = ['title must be between 1 and 100 characters'];
+		}
+	}
+
+	// body (optional)
+	if (hasBody) {
+		if (typeof obj.body !== 'string') {
+			errors.body = ['body must be a string'];
+		} else if (obj.body.length < 1 || obj.body.length > 50000) {
+			errors.body = ['body must be between 1 and 50000 characters'];
+		}
+	}
+
+	// tags (optional)
+	if (hasTags) {
+		if (!Array.isArray(obj.tags)) {
+			errors.tags = ['tags must be an array'];
+		} else if (obj.tags.length > 10) {
+			errors.tags = ['tags must have at most 10 items'];
+		} else if (!obj.tags.every((t: unknown) => typeof t === 'string')) {
+			errors.tags = ['each tag must be a string'];
+		}
+	}
+
+	// status (optional)
+	if (hasStatus) {
+		if (obj.status !== 'draft' && obj.status !== 'published') {
+			errors.status = ['status must be "draft" or "published"'];
+		}
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { success: false, errors };
+	}
+
+	const result: UpdateArticleInput = {};
+	if (hasTitle) result.title = obj.title as string;
+	if (hasBody) result.body = obj.body as string;
+	if (hasTags) result.tags = obj.tags as string[];
+	if (hasStatus) result.status = obj.status as 'draft' | 'published';
+
+	return { success: true, data: result };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,10 @@
+import { defineMiddleware } from 'astro:middleware';
+import { createDb } from './db';
+import { resolveUser } from './lib/auth';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+	const databaseUrl = context.locals.runtime.env.DATABASE_URL;
+	context.locals.db = createDb(databaseUrl);
+	context.locals.currentUser = await resolveUser(context.request, context.locals.db);
+	return next();
+});

--- a/src/pages/api/articles/[slug].ts
+++ b/src/pages/api/articles/[slug].ts
@@ -1,0 +1,77 @@
+import type { APIContext } from 'astro';
+import { deleteArticle, getArticleBySlug, updateArticle } from '../../../lib/articles';
+import { forbidden, notFound, unauthorized, validationError } from '../../../lib/errors';
+import { validateUpdateArticle } from '../../../lib/validation';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+
+	const article = await getArticleBySlug(db, slug);
+	if (!article) {
+		return notFound('Article not found');
+	}
+
+	if (article.status === 'draft' && currentUser?.id !== article.author.id) {
+		return notFound('Article not found');
+	}
+
+	return new Response(JSON.stringify({ data: article }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export async function PUT(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	const article = await getArticleBySlug(db, slug);
+	if (!article) {
+		return notFound('Article not found');
+	}
+
+	if (currentUser.id !== article.author.id && currentUser.role !== 'admin') {
+		return forbidden();
+	}
+
+	const body = await context.request.json();
+	const validation = validateUpdateArticle(body);
+
+	if (!validation.success) {
+		return validationError(validation.errors);
+	}
+
+	const updated = await updateArticle(db, article.id, validation.data);
+
+	return new Response(JSON.stringify({ data: updated }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export async function DELETE(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	const article = await getArticleBySlug(db, slug);
+	if (!article) {
+		return notFound('Article not found');
+	}
+
+	if (currentUser.id !== article.author.id && currentUser.role !== 'admin') {
+		return forbidden();
+	}
+
+	await deleteArticle(db, article.id);
+
+	return new Response(null, { status: 204 });
+}

--- a/src/pages/api/articles/index.ts
+++ b/src/pages/api/articles/index.ts
@@ -1,0 +1,53 @@
+import type { APIContext } from 'astro';
+import { createArticle, listArticles } from '../../../lib/articles';
+import { unauthorized, validationError } from '../../../lib/errors';
+import { validateCreateArticle } from '../../../lib/validation';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const params = context.url.searchParams;
+
+	const page = Number(params.get('page') ?? '1');
+	const limit = Number(params.get('limit') ?? '20');
+	const tag = params.get('tag') ?? undefined;
+	const validStatuses = ['draft', 'published', 'archived'] as const;
+	const rawStatus = params.get('status');
+	let status: (typeof validStatuses)[number] | undefined;
+
+	if (rawStatus && validStatuses.includes(rawStatus as (typeof validStatuses)[number])) {
+		status = rawStatus as (typeof validStatuses)[number];
+	}
+
+	if (status && !currentUser) {
+		status = 'published';
+	}
+
+	const result = await listArticles(db, { page, limit, tag, status });
+
+	return new Response(JSON.stringify(result), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export async function POST(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	const body = await context.request.json();
+	const validation = validateCreateArticle(body);
+
+	if (!validation.success) {
+		return validationError(validation.errors);
+	}
+
+	const article = await createArticle(db, validation.data, currentUser.id);
+
+	return new Response(JSON.stringify({ data: article }), {
+		status: 201,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}


### PR DESCRIPTION
## Summary

- 記事の CRUD API エンドポイント（`GET/POST /api/articles`, `GET/PUT/DELETE /api/articles/:slug`）を実装
- ページネーション、タグフィルタ、ステータスフィルタ対応の一覧取得
- 認証ヘルパー（仮実装: `Authorization: Bearer <user-id>`）とミドルウェアで DB・ユーザー注入
- バリデーション（title/body/tags/status）、統一エラーレスポンス形式
- FF14 カテゴリタグ（レイド、討滅戦、ダンジョン、タンク、ヒーラー、DPS 等）のシードスクリプト

### 新規ファイル
| ファイル | 内容 |
|---------|------|
| `src/env.d.ts` | `App.Locals` 型拡張（db, currentUser）|
| `src/middleware.ts` | DB注入 + 認証注入ミドルウェア |
| `src/lib/auth.ts` | 認証ヘルパー（仮実装） |
| `src/lib/errors.ts` | エラーレスポンスヘルパー |
| `src/lib/slug.ts` | slug 生成ユーティリティ |
| `src/lib/validation.ts` | 記事バリデーション |
| `src/lib/articles.ts` | 記事 CRUD ビジネスロジック |
| `src/pages/api/articles/index.ts` | 一覧取得 / 作成エンドポイント |
| `src/pages/api/articles/[slug].ts` | 詳細 / 更新 / 削除エンドポイント |
| `src/db/seed.ts` | FF14 タグシード |

Closes #6

## Test plan
- [ ] `pnpm biome check src/` — lint チェック通過
- [ ] `pnpm astro check` — 型チェック通過（0 errors）
- [ ] `pnpm build` — ビルド成功
- [ ] `pnpm db:seed` — タグシード実行確認
- [ ] API エンドポイントの動作確認（curl / REST クライアント）

🤖 Generated with [Claude Code](https://claude.com/claude-code)