### PR TITLE
fix: Cloudflare Workers で React SSR の MessageChannel エラーを修正 (#5)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,8 +14,14 @@ export default defineConfig({
 	integrations: [react()],
 	vite: {
 		plugins: [tailwindcss()],
+		resolve: {
+			conditions: ['workerd', 'worker', 'browser'],
+		},
 		ssr: {
 			external: ['node:crypto'],
+			resolve: {
+				conditions: ['workerd', 'worker', 'browser'],
+			},
 		},
 	},
 });


### PR DESCRIPTION
## Summary
- Vite の `resolve.conditions` に `workerd`, `worker`, `browser` を追加
- `react-dom/server` が Cloudflare Workers (Edge) 向けバンドルを使用するように設定
- これにより `MessageChannel is not defined` エラーが解消される

## 原因
React 19 の `react-dom/server.browser` は `MessageChannel` API に依存しており、Cloudflare Workers のモジュール評価時に利用できないため失敗していた。`workerd` resolve condition を指定することで、Edge 互換のバンドルが選択される。

## Test plan
- [x] `pnpm build` が正常に完了することを確認
- [ ] Cloudflare Pages へのデプロイが成功すること

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)