### PR TITLE
fix: Cloudflare Workers DB接続エラーと認証コールバックURLを修正 (#31)

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,15 +3,9 @@ import postgres from 'postgres';
 import * as schema from './schema';
 
 export function createDb(databaseUrl: string) {
-	const url = new URL(databaseUrl);
-	const client = postgres({
-		host: url.hostname,
-		port: Number(url.port),
-		database: url.pathname.slice(1),
-		username: url.username,
-		password: decodeURIComponent(url.password),
-		ssl: 'require',
+	const client = postgres(databaseUrl, {
 		prepare: false,
+		max: 1,
 	});
 	return drizzle(client, { schema });
 }

--- a/src/pages/api/auth/register.ts
+++ b/src/pages/api/auth/register.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 
 export const POST: APIRoute = async (context) => {
 	const { supabase } = context.locals;
+	const origin = new URL(context.request.url).origin;
 	const formData = await context.request.formData();
 	const email = formData.get('email')?.toString() ?? '';
 	const password = formData.get('password')?.toString() ?? '';
@@ -16,6 +17,7 @@ export const POST: APIRoute = async (context) => {
 				username,
 				display_name: displayName,
 			},
+			emailRedirectTo: `${origin}/api/auth/callback`,
 		},
 	});
 


### PR DESCRIPTION
## Summary
- Cloudflare Pages デプロイ後に 500 エラーでサイトにアクセスできない問題を修正
- ユーザー登録時のメール認証コールバックが `http://localhost:3000` にリダイレクトされる問題を修正

### DB接続エラー（500）
`postgres` ライブラリの `ssl: 'require'` が Cloudflare Workers の `cloudflare:sockets` STARTTLS 処理と互換性がなく "Too many subrequests" エラーが発生していた。SSL オプションを削除し、接続文字列を直接渡す方式にシンプル化。

### 認証コールバックURL
`register.ts` の `signUp()` で `emailRedirectTo` が未指定のため、Supabase ダッシュボードの Site URL（localhost）にリダイレクトされていた。リクエスト元の origin を使用して正しいコールバックURLを設定。

Closes #31

## Test plan
- [ ] Cloudflare Pages にデプロイしてトップページが 200 で表示される
- [ ] ユーザー登録後のメール認証リンクが本番URLにリダイレクトされる
- [ ] ログイン・ログアウトが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)