### PR TITLE
feat: OAuth認証後のユーザーネーム設定フロー（オンボーディング） (#34)

### DIFF
--- a/src/components/auth/OnboardingForm.tsx
+++ b/src/components/auth/OnboardingForm.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface OnboardingFormProps {
+	error?: string;
+	defaultDisplayName?: string;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+	missing_fields: 'すべての項目を入力してください。',
+	invalid_username: 'ユーザー名は英数字とアンダースコアのみ、3〜20文字で入力してください。',
+	invalid_display_name: '表示名は1〜50文字で入力してください。',
+	username_taken: 'このユーザー名は既に使用されています。',
+};
+
+export function OnboardingForm({ error, defaultDisplayName }: OnboardingFormProps) {
+	const [username, setUsername] = useState('');
+	const [usernameStatus, setUsernameStatus] = useState<
+		'idle' | 'checking' | 'available' | 'taken' | 'invalid'
+	>('idle');
+
+	const checkUsername = useCallback(async (value: string) => {
+		if (!/^[a-zA-Z0-9_]{3,20}$/.test(value)) {
+			setUsernameStatus(value.length > 0 ? 'invalid' : 'idle');
+			return;
+		}
+
+		setUsernameStatus('checking');
+		try {
+			const res = await fetch(`/api/auth/check-username?username=${encodeURIComponent(value)}`);
+			const data = await res.json();
+			setUsernameStatus(data.available ? 'available' : 'taken');
+		} catch {
+			setUsernameStatus('idle');
+		}
+	}, []);
+
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			if (username) {
+				checkUsername(username);
+			} else {
+				setUsernameStatus('idle');
+			}
+		}, 400);
+		return () => clearTimeout(timer);
+	}, [username, checkUsername]);
+
+	return (
+		<div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4">
+			<Card className="w-full max-w-md">
+				<CardHeader>
+					<CardTitle className="text-2xl">プロフィール設定</CardTitle>
+					<CardDescription>ユーザーネームと表示名を設定してください</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{error && (
+						<div className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+							{ERROR_MESSAGES[error] ?? 'エラーが発生しました。'}
+						</div>
+					)}
+
+					<form action="/api/auth/setup-profile" method="POST" className="space-y-4">
+						<div className="space-y-2">
+							<Label htmlFor="username">ユーザー名</Label>
+							<Input
+								id="username"
+								name="username"
+								type="text"
+								placeholder="username"
+								required
+								value={username}
+								onChange={(e) => setUsername(e.target.value)}
+							/>
+							<p className="text-xs text-muted-foreground">英数字とアンダースコアのみ、3〜20文字</p>
+							{usernameStatus === 'checking' && (
+								<p className="text-xs text-muted-foreground">確認中...</p>
+							)}
+							{usernameStatus === 'available' && (
+								<p className="text-xs text-green-600">このユーザー名は使用できます</p>
+							)}
+							{usernameStatus === 'taken' && (
+								<p className="text-xs text-destructive">このユーザー名は既に使用されています</p>
+							)}
+							{usernameStatus === 'invalid' && (
+								<p className="text-xs text-destructive">
+									英数字とアンダースコアのみ、3〜20文字で入力してください
+								</p>
+							)}
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="displayName">表示名</Label>
+							<Input
+								id="displayName"
+								name="displayName"
+								type="text"
+								placeholder="表示名"
+								defaultValue={defaultDisplayName}
+								required
+							/>
+						</div>
+						<Button type="submit" className="w-full" disabled={usernameStatus !== 'available'}>
+							設定を完了
+						</Button>
+					</form>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,8 @@ import { createDb } from './db';
 import { profiles } from './db/schema';
 import { createSupabaseClient } from './lib/supabase';
 
+const ONBOARDING_SKIP_PATHS = ['/onboarding', '/api/', '/login', '/register'];
+
 export const onRequest = defineMiddleware(async (context, next) => {
 	const env = context.locals.runtime.env;
 	context.locals.db = createDb(env.DATABASE_URL);
@@ -30,6 +32,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			email: user.email ?? '',
 			profile: profile ?? null,
 		};
+
+		if (!profile) {
+			const path = context.url.pathname;
+			const shouldSkip = ONBOARDING_SKIP_PATHS.some((p) => path.startsWith(p));
+			if (!shouldSkip) {
+				return context.redirect('/onboarding');
+			}
+		}
 	} else {
 		context.locals.currentUser = null;
 	}

--- a/src/pages/api/auth/check-username.ts
+++ b/src/pages/api/auth/check-username.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+import { eq } from 'drizzle-orm';
+import { profiles } from '../../../db/schema';
+
+export const GET: APIRoute = async (context) => {
+	const { db } = context.locals;
+	const username = context.url.searchParams.get('username') ?? '';
+
+	if (!/^[a-zA-Z0-9_]{3,20}$/.test(username)) {
+		return new Response(JSON.stringify({ available: false, reason: 'invalid' }), {
+			headers: { 'Content-Type': 'application/json' },
+		});
+	}
+
+	const [existing] = await db
+		.select({ id: profiles.id })
+		.from(profiles)
+		.where(eq(profiles.username, username))
+		.limit(1);
+
+	return new Response(JSON.stringify({ available: !existing }), {
+		headers: { 'Content-Type': 'application/json' },
+	});
+};

--- a/src/pages/api/auth/setup-profile.ts
+++ b/src/pages/api/auth/setup-profile.ts
@@ -1,0 +1,52 @@
+import type { APIRoute } from 'astro';
+import { eq } from 'drizzle-orm';
+import { profiles } from '../../../db/schema';
+
+export const POST: APIRoute = async (context) => {
+	const { supabase, db } = context.locals;
+
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return context.redirect('/login');
+	}
+
+	const formData = await context.request.formData();
+	const username = formData.get('username')?.toString()?.trim() ?? '';
+	const displayName = formData.get('displayName')?.toString()?.trim() ?? '';
+
+	if (!username || !displayName) {
+		return context.redirect('/onboarding?error=missing_fields');
+	}
+
+	if (!/^[a-zA-Z0-9_]{3,20}$/.test(username)) {
+		return context.redirect('/onboarding?error=invalid_username');
+	}
+
+	if (displayName.length < 1 || displayName.length > 50) {
+		return context.redirect('/onboarding?error=invalid_display_name');
+	}
+
+	const [existing] = await db
+		.select({ id: profiles.id })
+		.from(profiles)
+		.where(eq(profiles.username, username))
+		.limit(1);
+
+	if (existing) {
+		return context.redirect('/onboarding?error=username_taken');
+	}
+
+	const avatarUrl = user.user_metadata?.avatar_url ?? null;
+
+	await db.insert(profiles).values({
+		id: user.id,
+		username,
+		displayName,
+		avatarUrl,
+	});
+
+	return context.redirect('/');
+};

--- a/src/pages/onboarding.astro
+++ b/src/pages/onboarding.astro
@@ -1,0 +1,23 @@
+---
+import { OnboardingForm } from '../components/auth/OnboardingForm';
+import Layout from '../layouts/Layout.astro';
+
+const currentUser = Astro.locals.currentUser;
+
+if (!currentUser) {
+	return Astro.redirect('/login');
+}
+
+if (currentUser.profile) {
+	return Astro.redirect('/');
+}
+
+const error = Astro.url.searchParams.get('error') ?? undefined;
+
+const { data: { user } } = await Astro.locals.supabase.auth.getUser();
+const defaultDisplayName = user?.user_metadata?.full_name ?? user?.user_metadata?.name ?? '';
+---
+
+<Layout title="プロフィール設定">
+	<OnboardingForm error={error} defaultDisplayName={defaultDisplayName} client:load />
+</Layout>


### PR DESCRIPTION
## Summary
- Google OAuth で新規登録したユーザーが初回ログイン時にユーザーネームと表示名を設定できるオンボーディングフローを実装
- プロフィール未設定ユーザーは自動的に `/onboarding` にリダイレクトされる
- ユーザーネームのリアルタイムバリデーション（一意性・形式チェック）付き

### 新規ファイル
- `src/pages/onboarding.astro` — オンボーディングページ
- `src/components/auth/OnboardingForm.tsx` — フォームコンポーネント（ユーザーネーム重複チェック付き）
- `src/pages/api/auth/setup-profile.ts` — プロフィール作成API
- `src/pages/api/auth/check-username.ts` — ユーザーネーム重複チェックAPI

### 変更ファイル
- `src/middleware.ts` — プロフィール未設定ユーザーを `/onboarding` にリダイレクトするロジック追加

### 認証フロー
```
Google OAuth → callback → ホーム → middleware がprofileチェック
  → profileあり → そのまま表示
  → profileなし → /onboarding → ユーザーネーム設定 → profile作成 → ホーム
```

Closes #34

## Test plan
- [ ] Google OAuthで新規登録後、/onboarding ページにリダイレクトされることを確認
- [ ] ユーザーネームと表示名を入力してプロフィールが作成されることを確認
- [ ] 重複ユーザーネームがリアルタイムで検出されることを確認
- [ ] 不正なユーザーネーム（記号、短すぎ、長すぎ）がバリデーションされることを確認
- [ ] プロフィール設定後、ホームページにリダイレクトされることを確認
- [ ] 2回目以降のログインでオンボーディングがスキップされることを確認
- [ ] プロフィール未設定状態で他のページにアクセスすると /onboarding にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)