### PR TITLE
feat: 記事エディターページを実装 (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"astro": "^5.17.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"dompurify": "^3.3.1",
 		"drizzle-orm": "^0.45.1",
 		"lucide-react": "^0.576.0",
 		"marked": "^17.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dompurify:
+        specifier: ^3.3.1
+        version: 3.3.1
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@cloudflare/workers-types@4.20260301.1)(@neondatabase/serverless@1.0.2)(@types/pg@8.18.0)(postgres@3.4.8)
@@ -2484,6 +2487,9 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -2941,6 +2947,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7250,6 +7259,9 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
@@ -7760,6 +7772,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:

--- a/src/components/editor/ArticleEditor.tsx
+++ b/src/components/editor/ArticleEditor.tsx
@@ -1,0 +1,184 @@
+import { Save, Send } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { TagInfo } from '@/lib/tags';
+import { ImageUploader } from './ImageUploader';
+import { MarkdownPreview } from './MarkdownPreview';
+import { TagSelector } from './TagSelector';
+
+interface ArticleData {
+	id: string;
+	title: string;
+	slug: string;
+	body: string;
+	status: string;
+	tags: TagInfo[];
+}
+
+interface ArticleEditorProps {
+	mode: 'new' | 'edit';
+	tags: TagInfo[];
+	article?: ArticleData;
+}
+
+export function ArticleEditor({ mode, tags, article }: ArticleEditorProps) {
+	const [title, setTitle] = useState(article?.title ?? '');
+	const [body, setBody] = useState(article?.body ?? '');
+	const [selectedTags, setSelectedTags] = useState<string[]>(article?.tags.map((t) => t.id) ?? []);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [errors, setErrors] = useState<Record<string, string[]>>({});
+	const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit');
+
+	const handleImageInsert = useCallback((markdown: string) => {
+		setBody((prev) => `${prev}\n${markdown}\n`);
+	}, []);
+
+	async function handleSubmit(status: 'draft' | 'published') {
+		setErrors({});
+		setIsSubmitting(true);
+
+		try {
+			const payload = { title, body, tags: selectedTags, status };
+
+			const url = mode === 'new' ? '/api/articles' : `/api/articles/${article?.slug}`;
+			const method = mode === 'new' ? 'POST' : 'PUT';
+
+			const res = await fetch(url, {
+				method,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload),
+			});
+
+			if (!res.ok) {
+				const json = await res.json();
+				const errBody = json?.error;
+				if (errBody?.details) {
+					setErrors(errBody.details);
+				} else {
+					setErrors({ _: [errBody?.message ?? '保存に失敗しました'] });
+				}
+				return;
+			}
+
+			const { data } = await res.json();
+			window.location.href = `/articles/${data.slug}`;
+		} catch {
+			setErrors({ _: ['ネットワークエラーが発生しました'] });
+		} finally {
+			setIsSubmitting(false);
+		}
+	}
+
+	return (
+		<div className="space-y-6">
+			{/* Global errors */}
+			{errors._ && (
+				<div className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+					{errors._.map((msg) => (
+						<p key={msg}>{msg}</p>
+					))}
+				</div>
+			)}
+
+			{/* Title */}
+			<div className="space-y-2">
+				<Label htmlFor="title">タイトル</Label>
+				<Input
+					id="title"
+					value={title}
+					onChange={(e) => setTitle(e.target.value)}
+					placeholder="記事のタイトル"
+					maxLength={100}
+					aria-invalid={!!errors.title}
+				/>
+				{errors.title && <p className="text-sm text-destructive">{errors.title[0]}</p>}
+				<p className="text-xs text-muted-foreground text-right">{title.length}/100</p>
+			</div>
+
+			{/* Tags */}
+			<TagSelector tags={tags} selectedIds={selectedTags} onChange={setSelectedTags} />
+			{errors.tags && <p className="text-sm text-destructive">{errors.tags[0]}</p>}
+
+			{/* Editor / Preview */}
+			<div className="space-y-2">
+				<Label>本文</Label>
+
+				{/* Mobile tab switcher */}
+				<div className="flex gap-1 md:hidden">
+					<button
+						type="button"
+						onClick={() => setActiveTab('edit')}
+						className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+							activeTab === 'edit'
+								? 'bg-secondary text-foreground'
+								: 'text-muted-foreground hover:text-foreground'
+						}`}
+					>
+						エディター
+					</button>
+					<button
+						type="button"
+						onClick={() => setActiveTab('preview')}
+						className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+							activeTab === 'preview'
+								? 'bg-secondary text-foreground'
+								: 'text-muted-foreground hover:text-foreground'
+						}`}
+					>
+						プレビュー
+					</button>
+				</div>
+
+				{/* Two-column layout (desktop) / Tab content (mobile) */}
+				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div className={activeTab !== 'edit' ? 'hidden md:block' : ''}>
+						<textarea
+							value={body}
+							onChange={(e) => setBody(e.target.value)}
+							placeholder="Markdown で記事を書く..."
+							className="h-[500px] w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 outline-none font-mono dark:bg-input/30"
+							aria-invalid={!!errors.body}
+						/>
+						{errors.body && <p className="text-sm text-destructive mt-1">{errors.body[0]}</p>}
+						<p className="text-xs text-muted-foreground text-right mt-1">
+							{body.length.toLocaleString()}/50,000
+						</p>
+					</div>
+					<div
+						className={`rounded-md border border-border p-4 overflow-y-auto h-[500px] ${
+							activeTab !== 'preview' ? 'hidden md:block' : ''
+						}`}
+					>
+						{body ? (
+							<MarkdownPreview body={body} />
+						) : (
+							<p className="text-sm text-muted-foreground">プレビューがここに表示されます</p>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{/* Image uploader */}
+			<ImageUploader onInsert={handleImageInsert} />
+
+			{/* Submit buttons */}
+			<div className="flex flex-wrap gap-3 justify-end pt-4 border-t border-border">
+				<Button
+					type="button"
+					variant="outline"
+					disabled={isSubmitting}
+					onClick={() => handleSubmit('draft')}
+				>
+					<Save className="h-4 w-4" />
+					下書き保存
+				</Button>
+				<Button type="button" disabled={isSubmitting} onClick={() => handleSubmit('published')}>
+					<Send className="h-4 w-4" />
+					公開する
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/editor/ImageUploader.tsx
+++ b/src/components/editor/ImageUploader.tsx
@@ -1,0 +1,148 @@
+import { Upload, X } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
+interface ImageUploaderProps {
+	onInsert: (markdown: string) => void;
+}
+
+export function ImageUploader({ onInsert }: ImageUploaderProps) {
+	const [isDragging, setIsDragging] = useState(false);
+	const [isUploading, setIsUploading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const upload = useCallback(
+		async (file: File) => {
+			setError(null);
+
+			if (!ALLOWED_TYPES.has(file.type)) {
+				setError('対応形式: PNG, JPEG, WebP, GIF');
+				return;
+			}
+			if (file.size > MAX_SIZE) {
+				setError('ファイルサイズは5MB以下にしてください');
+				return;
+			}
+
+			setIsUploading(true);
+			try {
+				// Step 1: Get upload URL
+				const metaRes = await fetch('/api/images/upload', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						filename: file.name,
+						contentType: file.type,
+						size: file.size,
+					}),
+				});
+
+				if (!metaRes.ok) {
+					const err = await metaRes.json();
+					throw new Error(err.message ?? 'アップロードURLの取得に失敗しました');
+				}
+
+				const { uploadUrl, imageUrl } = await metaRes.json();
+
+				// Step 2: Upload binary to R2
+				const putRes = await fetch(uploadUrl, {
+					method: 'PUT',
+					headers: { 'Content-Type': file.type },
+					body: file,
+				});
+
+				if (!putRes.ok) {
+					throw new Error('画像のアップロードに失敗しました');
+				}
+
+				// Step 3: Insert markdown
+				const safeAlt = file.name.replace(/[[\]()]/g, '');
+				onInsert(`![${safeAlt}](${imageUrl})`);
+			} catch (e) {
+				setError(e instanceof Error ? e.message : 'アップロードに失敗しました');
+			} finally {
+				setIsUploading(false);
+			}
+		},
+		[onInsert],
+	);
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			setIsDragging(false);
+
+			const file = e.dataTransfer.files[0];
+			if (file) upload(file);
+		},
+		[upload],
+	);
+
+	const handleFileChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (file) upload(file);
+			if (inputRef.current) inputRef.current.value = '';
+		},
+		[upload],
+	);
+
+	return (
+		<div className="space-y-2">
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: Drop zone requires drag events on div */}
+			<div
+				onDragOver={(e) => {
+					e.preventDefault();
+					setIsDragging(true);
+				}}
+				onDragLeave={() => setIsDragging(false)}
+				onDrop={handleDrop}
+				className={`rounded-lg border-2 border-dashed p-4 text-center transition-colors ${
+					isDragging
+						? 'border-primary bg-primary/5'
+						: 'border-border hover:border-muted-foreground/50'
+				}`}
+			>
+				{isUploading ? (
+					<div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+						<div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+						アップロード中...
+					</div>
+				) : (
+					<div className="space-y-2">
+						<Upload className="mx-auto h-6 w-6 text-muted-foreground" />
+						<p className="text-sm text-muted-foreground">ドラッグ&ドロップ または</p>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={() => inputRef.current?.click()}
+						>
+							ファイルを選択
+						</Button>
+						<p className="text-xs text-muted-foreground">PNG, JPEG, WebP, GIF（最大5MB）</p>
+					</div>
+				)}
+			</div>
+
+			{error && (
+				<div className="flex items-center gap-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+					<X className="h-4 w-4 shrink-0" />
+					{error}
+				</div>
+			)}
+
+			<input
+				ref={inputRef}
+				type="file"
+				accept="image/png,image/jpeg,image/webp,image/gif"
+				onChange={handleFileChange}
+				className="hidden"
+			/>
+		</div>
+	);
+}

--- a/src/components/editor/MarkdownPreview.tsx
+++ b/src/components/editor/MarkdownPreview.tsx
@@ -1,0 +1,38 @@
+import DOMPurify from 'dompurify';
+import { Marked } from 'marked';
+import { useEffect, useState } from 'react';
+
+const marked = new Marked();
+
+interface MarkdownPreviewProps {
+	body: string;
+}
+
+export function MarkdownPreview({ body }: MarkdownPreviewProps) {
+	const [html, setHtml] = useState('');
+
+	useEffect(() => {
+		let cancelled = false;
+
+		async function render() {
+			const raw = await marked.parse(body);
+			const sanitized = DOMPurify.sanitize(raw, { FORCE_BODY: true });
+			if (!cancelled) {
+				setHtml(sanitized);
+			}
+		}
+
+		render();
+		return () => {
+			cancelled = true;
+		};
+	}, [body]);
+
+	return (
+		<div
+			className="article-content prose-preview"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: Content sanitized via DOMPurify
+			dangerouslySetInnerHTML={{ __html: html }}
+		/>
+	);
+}

--- a/src/components/editor/TagSelector.tsx
+++ b/src/components/editor/TagSelector.tsx
@@ -1,0 +1,70 @@
+import { Label } from '@/components/ui/label';
+import type { TagInfo } from '@/lib/tags';
+
+interface TagSelectorProps {
+	tags: TagInfo[];
+	selectedIds: string[];
+	onChange: (ids: string[]) => void;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+	duty: 'コンテンツ',
+	job: 'ジョブ',
+	crafting: 'クラフター',
+	gathering: 'ギャザラー',
+	general: '全般',
+};
+
+export function TagSelector({ tags, selectedIds, onChange }: TagSelectorProps) {
+	const grouped = new Map<string, TagInfo[]>();
+	for (const tag of tags) {
+		const list = grouped.get(tag.category) ?? [];
+		list.push(tag);
+		grouped.set(tag.category, list);
+	}
+
+	function handleToggle(tagId: string) {
+		if (selectedIds.includes(tagId)) {
+			onChange(selectedIds.filter((id) => id !== tagId));
+		} else if (selectedIds.length < 10) {
+			onChange([...selectedIds, tagId]);
+		}
+	}
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center justify-between">
+				<Label>タグ</Label>
+				<span className="text-xs text-muted-foreground">{selectedIds.length}/10</span>
+			</div>
+			{[...grouped.entries()].map(([category, categoryTags]) => (
+				<div key={category}>
+					<p className="text-xs font-medium text-muted-foreground mb-2">
+						{CATEGORY_LABELS[category] ?? category}
+					</p>
+					<div className="flex flex-wrap gap-2">
+						{categoryTags.map((tag) => {
+							const isSelected = selectedIds.includes(tag.id);
+							return (
+								<button
+									key={tag.id}
+									type="button"
+									onClick={() => handleToggle(tag.id)}
+									disabled={!isSelected && selectedIds.length >= 10}
+									aria-pressed={isSelected}
+									className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
+										isSelected
+											? 'bg-primary text-primary-foreground'
+											: 'bg-secondary text-muted-foreground hover:bg-secondary/80 disabled:opacity-50'
+									}`}
+								>
+									{tag.name}
+								</button>
+							);
+						})}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,27 @@
+import type { InferSelectModel } from 'drizzle-orm';
+import { asc } from 'drizzle-orm';
+import type { Database } from '../db';
+import { tags } from '../db/schema';
+
+type TagRow = InferSelectModel<typeof tags>;
+
+export interface TagInfo {
+	id: string;
+	name: string;
+	slug: string;
+	category: TagRow['category'];
+}
+
+export async function listTags(db: Database): Promise<TagInfo[]> {
+	const rows = await db
+		.select({
+			id: tags.id,
+			name: tags.name,
+			slug: tags.slug,
+			category: tags.category,
+		})
+		.from(tags)
+		.orderBy(asc(tags.category), asc(tags.name));
+
+	return rows;
+}

--- a/src/pages/articles/[slug]/edit.astro
+++ b/src/pages/articles/[slug]/edit.astro
@@ -1,0 +1,46 @@
+---
+import { ArticleEditor } from '../../../components/editor/ArticleEditor';
+import Layout from '../../../layouts/Layout.astro';
+import { getArticleBySlug } from '../../../lib/articles';
+import { listTags, type TagInfo } from '../../../lib/tags';
+
+const { currentUser } = Astro.locals;
+
+if (!currentUser) {
+	return Astro.redirect('/login');
+}
+
+const { slug } = Astro.params;
+const article = await getArticleBySlug(Astro.locals.db, slug ?? '');
+
+if (!article) {
+	return Astro.redirect('/404');
+}
+
+const isAuthor = currentUser.id === article.author.id;
+const isAdmin = currentUser.profile?.role === 'admin';
+
+if (!isAuthor && !isAdmin) {
+	if (article.status === 'draft') {
+		return Astro.redirect('/404');
+	}
+	return new Response(null, { status: 403, statusText: 'Forbidden' });
+}
+
+const tags = await listTags(Astro.locals.db);
+const articleData = {
+	id: article.id,
+	title: article.title,
+	slug: article.slug,
+	body: article.body,
+	status: article.status,
+	tags: article.tags as TagInfo[],
+};
+---
+
+<Layout title={`${article.title} を編集`}>
+	<div class="py-4">
+		<h1 class="text-2xl font-bold mb-6">記事を編集</h1>
+		<ArticleEditor client:load mode="edit" tags={tags} article={articleData} />
+	</div>
+</Layout>

--- a/src/pages/articles/new.astro
+++ b/src/pages/articles/new.astro
@@ -1,0 +1,20 @@
+---
+import { ArticleEditor } from '../../components/editor/ArticleEditor';
+import Layout from '../../layouts/Layout.astro';
+import { listTags } from '../../lib/tags';
+
+const { currentUser } = Astro.locals;
+
+if (!currentUser) {
+	return Astro.redirect('/login');
+}
+
+const tags = await listTags(Astro.locals.db);
+---
+
+<Layout title="記事を作成">
+	<div class="py-4">
+		<h1 class="text-2xl font-bold mb-6">記事を作成</h1>
+		<ArticleEditor client:load mode="new" tags={tags} />
+	</div>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -122,3 +122,138 @@
 		@apply bg-background text-foreground;
 	}
 }
+
+/* Markdown preview styles (mirrors ArticleContent.astro scoped styles) */
+.prose-preview {
+	color: var(--foreground);
+	line-height: 1.8;
+	font-size: 1rem;
+}
+.prose-preview h1 {
+	font-size: 2rem;
+	font-weight: 700;
+	margin-top: 2.5rem;
+	margin-bottom: 1rem;
+	padding-bottom: 0.5rem;
+	border-bottom: 1px solid var(--border);
+}
+.prose-preview h2 {
+	font-size: 1.5rem;
+	font-weight: 700;
+	margin-top: 2rem;
+	margin-bottom: 0.75rem;
+	padding-bottom: 0.375rem;
+	border-bottom: 1px solid var(--border);
+}
+.prose-preview h3 {
+	font-size: 1.25rem;
+	font-weight: 600;
+	margin-top: 1.5rem;
+	margin-bottom: 0.5rem;
+}
+.prose-preview h4 {
+	font-size: 1.125rem;
+	font-weight: 600;
+	margin-top: 1.25rem;
+	margin-bottom: 0.5rem;
+}
+.prose-preview p {
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+}
+.prose-preview a {
+	color: var(--primary);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+.prose-preview a:hover {
+	opacity: 0.8;
+}
+.prose-preview ul {
+	list-style-type: disc;
+	padding-left: 1.5rem;
+	margin-top: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+.prose-preview ol {
+	list-style-type: decimal;
+	padding-left: 1.5rem;
+	margin-top: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+.prose-preview li {
+	margin-top: 0.25rem;
+	margin-bottom: 0.25rem;
+}
+.prose-preview blockquote {
+	border-left: 4px solid var(--primary);
+	padding-left: 1rem;
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+	color: var(--muted-foreground);
+	font-style: italic;
+}
+.prose-preview code {
+	background-color: var(--secondary);
+	padding: 0.125rem 0.375rem;
+	border-radius: 0.25rem;
+	font-size: 0.875em;
+}
+.prose-preview pre {
+	margin-top: 1.25rem;
+	margin-bottom: 1.25rem;
+	padding: 1rem;
+	border-radius: 0.5rem;
+	overflow-x: auto;
+	font-size: 0.875rem;
+	line-height: 1.6;
+	background-color: var(--secondary);
+	border: 1px solid var(--border);
+}
+.prose-preview pre code {
+	background-color: transparent;
+	padding: 0;
+	border-radius: 0;
+	font-size: inherit;
+}
+.prose-preview table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-top: 1.25rem;
+	margin-bottom: 1.25rem;
+	font-size: 0.875rem;
+}
+.prose-preview thead {
+	border-bottom: 2px solid var(--border);
+}
+.prose-preview th {
+	padding: 0.625rem 0.75rem;
+	text-align: left;
+	font-weight: 600;
+}
+.prose-preview td {
+	padding: 0.625rem 0.75rem;
+	border-bottom: 1px solid var(--border);
+}
+.prose-preview tr:hover {
+	background-color: var(--secondary);
+}
+.prose-preview hr {
+	border: none;
+	border-top: 1px solid var(--border);
+	margin-top: 2rem;
+	margin-bottom: 2rem;
+}
+.prose-preview img {
+	max-width: 100%;
+	height: auto;
+	border-radius: 0.5rem;
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+}
+.prose-preview strong {
+	font-weight: 700;
+}
+.prose-preview em {
+	font-style: italic;
+}


### PR DESCRIPTION
## Summary
- Markdownエディター（リアルタイムプレビュー付き）、タグ選択、画像アップロード、下書き保存/公開機能を含む記事作成・編集ページを追加
- DOMPurifyによるXSS対策、ファイル名サニタイズ、ドラフト記事の存在漏洩防止などセキュリティ対策を実装
- モバイルではタブ切り替え、デスクトップでは2カラムのレスポンシブ対応

### 新規ファイル
| ファイル | 役割 |
|---|---|
| `src/lib/tags.ts` | タグ取得ユーティリティ（カテゴリ順ソート） |
| `src/components/editor/ArticleEditor.tsx` | エディターコンテナ（新規/編集両対応） |
| `src/components/editor/MarkdownPreview.tsx` | marked + DOMPurify によるリアルタイムプレビュー |
| `src/components/editor/TagSelector.tsx` | カテゴリ別チェックボックス（最大10個） |
| `src/components/editor/ImageUploader.tsx` | ドラッグ&ドロップ画像アップロード |
| `src/pages/articles/new.astro` | 新規作成ページ（認証ガード付き） |
| `src/pages/articles/[slug]/edit.astro` | 編集ページ（著者/admin権限ガード付き） |

Closes #9

## Test plan
- [ ] `/articles/new` でエディターが表示される
- [ ] Markdown 入力 → リアルタイムプレビュー更新
- [ ] タグ選択/解除（最大10個制限）
- [ ] 画像アップロード → 本文に Markdown 画像記法を挿入
- [ ] 下書き保存 / 公開が動作する
- [ ] バリデーションエラーが適切に表示される
- [ ] 未認証ユーザーは `/login` にリダイレクトされる
- [ ] 権限のないユーザーは 403 / 404 になる
- [ ] モバイルでタブ切り替えが機能する
- [ ] `pnpm astro check` / `pnpm biome check .` がエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)