### PR TITLE
fix: shikiをCloudflare Workers互換のJSエンジンに変更 (#41)

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,25 +1,28 @@
 import { Marked } from 'marked';
-import { createHighlighter, type Highlighter } from 'shiki';
+import { createHighlighterCore, type HighlighterCore } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import vitesseDark from 'shiki/themes/vitesse-dark.mjs';
 
-let highlighterPromise: Promise<Highlighter> | null = null;
+let highlighterPromise: Promise<HighlighterCore> | null = null;
 
-function getHighlighter(): Promise<Highlighter> {
+function getHighlighter(): Promise<HighlighterCore> {
 	if (!highlighterPromise) {
-		highlighterPromise = createHighlighter({
-			themes: ['vitesse-dark'],
+		highlighterPromise = createHighlighterCore({
+			themes: [vitesseDark],
 			langs: [
-				'javascript',
-				'typescript',
-				'html',
-				'css',
-				'json',
-				'markdown',
-				'bash',
-				'yaml',
-				'xml',
-				'python',
-				'lua',
+				import('shiki/langs/javascript.mjs'),
+				import('shiki/langs/typescript.mjs'),
+				import('shiki/langs/html.mjs'),
+				import('shiki/langs/css.mjs'),
+				import('shiki/langs/json.mjs'),
+				import('shiki/langs/markdown.mjs'),
+				import('shiki/langs/bash.mjs'),
+				import('shiki/langs/yaml.mjs'),
+				import('shiki/langs/xml.mjs'),
+				import('shiki/langs/python.mjs'),
+				import('shiki/langs/lua.mjs'),
 			],
+			engine: createJavaScriptRegexEngine(),
 		});
 	}
 	return highlighterPromise;


### PR DESCRIPTION
## Summary
- 記事詳細ページ (`/articles/[slug]`) で発生していた500エラーを修正
- `shiki` の `createHighlighter`（WASM依存）を `createHighlighterCore` + JavaScript RegExp エンジンに変更し、Cloudflare Workers 環境での互換性を確保

## Changes
- `src/lib/markdown.ts`:
  - `shiki` → `shiki/core` + `shiki/engine/javascript` に変更
  - テーマ・言語を動的インポートに変更（tree-shaking対応）
  - WASM不要の JavaScript RegExp エンジンを使用

## Root Cause
`shiki` のデフォルトインポートは内部で Oniguruma WASM を読み込むが、Cloudflare Workers ランタイムではバイナリデータからの WASM 初期化がサポートされておらず、500エラーが発生していた。

Closes #41

## Test plan
- [ ] 本番環境で `/articles/[slug]` にアクセスして記事詳細が正常に表示されることを確認
- [ ] Markdownのシンタックスハイライトが動作することを確認
- [ ] ビルドが正常に完了することを確認（✅ ローカルで確認済み）
- [ ] 型チェックが通ることを確認（✅ ローカルで確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)