### PR TITLE
feat: タグ一覧 API エンドポイントを追加 (#45)

### DIFF
--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,27 +1,52 @@
 import type { InferSelectModel } from 'drizzle-orm';
-import { asc } from 'drizzle-orm';
+import { asc, eq } from 'drizzle-orm';
 import type { Database } from '../db';
 import { tags } from '../db/schema';
 
 type TagRow = InferSelectModel<typeof tags>;
 
+export type TagCategory = TagRow['category'];
+
+export const TAG_CATEGORIES = ['duty', 'job', 'crafting', 'gathering', 'general'] as const;
+
 export interface TagInfo {
 	id: string;
 	name: string;
 	slug: string;
-	category: TagRow['category'];
+	category: TagCategory;
 }
 
-export async function listTags(db: Database): Promise<TagInfo[]> {
-	const rows = await db
+export interface ListTagsOptions {
+	category?: TagCategory;
+}
+
+export async function listTags(db: Database, options: ListTagsOptions = {}): Promise<TagInfo[]> {
+	const query = db
 		.select({
 			id: tags.id,
 			name: tags.name,
 			slug: tags.slug,
 			category: tags.category,
 		})
-		.from(tags)
-		.orderBy(asc(tags.category), asc(tags.name));
+		.from(tags);
+
+	const rows = options.category
+		? await query
+				.where(eq(tags.category, options.category))
+				.orderBy(asc(tags.category), asc(tags.name))
+		: await query.orderBy(asc(tags.category), asc(tags.name));
 
 	return rows;
+}
+
+export type GroupedTags = Record<string, TagInfo[]>;
+
+export function groupTagsByCategory(tagList: TagInfo[]): GroupedTags {
+	const grouped: GroupedTags = {};
+	for (const tag of tagList) {
+		const list = grouped[tag.category] ?? [];
+		list.push(tag);
+		grouped[tag.category] = list;
+	}
+	return grouped;
 }

--- a/src/pages/api/tags/index.ts
+++ b/src/pages/api/tags/index.ts
@@ -1,0 +1,33 @@
+import type { APIContext } from 'astro';
+import { groupTagsByCategory, listTags, TAG_CATEGORIES, type TagCategory } from '../../../lib/tags';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db } = context.locals;
+	const params = context.url.searchParams;
+
+	const rawCategory = params.get('category');
+	let category: TagCategory | undefined;
+
+	if (rawCategory) {
+		if (!(TAG_CATEGORIES as readonly string[]).includes(rawCategory)) {
+			return new Response(
+				JSON.stringify({
+					error: {
+						code: 'VALIDATION_ERROR',
+						message: `Invalid category. Must be one of: ${TAG_CATEGORIES.join(', ')}`,
+					},
+				}),
+				{ status: 400, headers: { 'Content-Type': 'application/json' } },
+			);
+		}
+		category = rawCategory as TagCategory;
+	}
+
+	const tagList = await listTags(db, { category });
+	const grouped = groupTagsByCategory(tagList);
+
+	return new Response(JSON.stringify({ data: grouped }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}


### PR DESCRIPTION
## Summary
- `GET /api/tags` エンドポイントを新規追加（カテゴリ別グループ化レスポンス）
- `?category=duty` のようなカテゴリフィルタリングに対応
- `src/lib/tags.ts` に `ListTagsOptions` / `groupTagsByCategory()` を追加（既存の `listTags()` は後方互換性維持）

Closes #45

## Test plan
- [ ] `GET /api/tags` で全タグがカテゴリごとにグループ化されて返ること
- [ ] `GET /api/tags?category=duty` で duty カテゴリのタグのみ返ること
- [ ] `GET /api/tags?category=invalid` で 400 エラーが返ること
- [ ] 既存の記事エディタ（TagSelector）が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)