### PR TITLE
feat: リアクション（👍）機能と人気順ソートを実装 (#11)

### DIFF
--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+interface ReactionButtonProps {
+	slug: string;
+	initialCount: number;
+	initialReacted: boolean;
+	isAuthenticated: boolean;
+}
+
+export default function ReactionButton({
+	slug,
+	initialCount,
+	initialReacted,
+	isAuthenticated,
+}: ReactionButtonProps) {
+	const [count, setCount] = useState(initialCount);
+	const [reacted, setReacted] = useState(initialReacted);
+	const [isLoading, setIsLoading] = useState(false);
+	const [showLoginHint, setShowLoginHint] = useState(false);
+
+	async function handleClick() {
+		if (!isAuthenticated) {
+			setShowLoginHint(true);
+			return;
+		}
+
+		const prevCount = count;
+		const prevReacted = reacted;
+
+		// 楽観的更新
+		setReacted(!reacted);
+		setCount(reacted ? count - 1 : count + 1);
+		setIsLoading(true);
+
+		try {
+			const res = await fetch(`/api/articles/${slug}/reactions`, {
+				method: 'POST',
+			});
+
+			if (!res.ok) {
+				// エラー時はUIを元に戻す
+				setCount(prevCount);
+				setReacted(prevReacted);
+				return;
+			}
+
+			const json = await res.json();
+			setCount(json.count);
+			setReacted(json.reacted);
+		} catch {
+			// ネットワークエラー時もUIを元に戻す
+			setCount(prevCount);
+			setReacted(prevReacted);
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<div className="flex flex-col items-start gap-2">
+			<button
+				type="button"
+				onClick={handleClick}
+				disabled={isLoading}
+				className={`inline-flex items-center gap-1.5 rounded-md border px-4 py-2 text-sm font-medium transition-all hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed ${
+					reacted
+						? 'border-primary bg-primary/10 text-primary'
+						: 'border-border bg-card text-muted-foreground hover:text-foreground'
+				}`}
+			>
+				<span>👍</span>
+				<span>{count}</span>
+			</button>
+			{showLoginHint && (
+				<a href="/login" className="text-sm text-primary hover:underline transition-colors">
+					ログインしてリアクション
+				</a>
+			)}
+		</div>
+	);
+}

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -1,6 +1,6 @@
-import { and, count, desc, eq, inArray } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { Database } from '../db';
-import { articles, articleTags, profiles, tags } from '../db/schema';
+import { articles, articleTags, profiles, reactions, tags } from '../db/schema';
 import { generateSlug } from './slug';
 
 export interface ListArticlesOptions {
@@ -8,6 +8,7 @@ export interface ListArticlesOptions {
 	limit?: number;
 	tag?: string;
 	status?: 'draft' | 'published' | 'archived';
+	sort?: 'newest' | 'popular';
 }
 
 export interface CreateArticleData {
@@ -111,30 +112,66 @@ export async function listArticles(db: Database, options: ListArticlesOptions = 
 
 	const where = and(...conditions);
 
-	const [totalResult, rows] = await Promise.all([
-		db.select({ total: count() }).from(articles).where(where),
-		db
+	const sort = options.sort ?? 'newest';
+
+	const selectFields = {
+		id: articles.id,
+		title: articles.title,
+		slug: articles.slug,
+		body: articles.body,
+		status: articles.status,
+		publishedAt: articles.publishedAt,
+		createdAt: articles.createdAt,
+		updatedAt: articles.updatedAt,
+		authorId: profiles.id,
+		authorUsername: profiles.username,
+		authorDisplayName: profiles.displayName,
+		authorAvatarUrl: profiles.avatarUrl,
+	};
+
+	const totalResult = await db.select({ total: count() }).from(articles).where(where);
+
+	let rows: {
+		id: string;
+		title: string;
+		slug: string;
+		body: string;
+		status: string;
+		publishedAt: Date | null;
+		createdAt: Date;
+		updatedAt: Date;
+		authorId: string | null;
+		authorUsername: string | null;
+		authorDisplayName: string | null;
+		authorAvatarUrl: string | null;
+	}[];
+
+	if (sort === 'popular') {
+		const reactionCount = sql<number>`count(${reactions.userId})`.as('reaction_count');
+
+		rows = await db
 			.select({
-				id: articles.id,
-				title: articles.title,
-				slug: articles.slug,
-				body: articles.body,
-				status: articles.status,
-				publishedAt: articles.publishedAt,
-				createdAt: articles.createdAt,
-				updatedAt: articles.updatedAt,
-				authorId: profiles.id,
-				authorUsername: profiles.username,
-				authorDisplayName: profiles.displayName,
-				authorAvatarUrl: profiles.avatarUrl,
+				...selectFields,
+				reactionCount,
 			})
+			.from(articles)
+			.leftJoin(profiles, eq(articles.authorId, profiles.id))
+			.leftJoin(reactions, eq(articles.id, reactions.articleId))
+			.where(where)
+			.groupBy(articles.id, profiles.id)
+			.orderBy(desc(reactionCount), desc(articles.publishedAt))
+			.limit(limit)
+			.offset(offset);
+	} else {
+		rows = await db
+			.select(selectFields)
 			.from(articles)
 			.leftJoin(profiles, eq(articles.authorId, profiles.id))
 			.where(where)
 			.orderBy(desc(articles.createdAt))
 			.limit(limit)
-			.offset(offset),
-	]);
+			.offset(offset);
+	}
 
 	const total = totalResult[0]?.total ?? 0;
 	const articleIds = rows.map((r) => r.id);

--- a/src/pages/api/articles/[slug]/reactions.ts
+++ b/src/pages/api/articles/[slug]/reactions.ts
@@ -1,0 +1,91 @@
+import type { APIContext } from 'astro';
+import { and, count, eq } from 'drizzle-orm';
+import { articles, reactions } from '../../../../db/schema';
+import { notFound, unauthorized } from '../../../../lib/errors';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+
+	const articleRow = await db
+		.select({ id: articles.id })
+		.from(articles)
+		.where(eq(articles.slug, slug))
+		.limit(1);
+
+	if (articleRow.length === 0) {
+		return notFound('Article not found');
+	}
+
+	const articleId = articleRow[0].id;
+
+	const [countResult] = await db
+		.select({ count: count() })
+		.from(reactions)
+		.where(eq(reactions.articleId, articleId));
+
+	let reacted = false;
+	if (currentUser) {
+		const userReaction = await db
+			.select({ userId: reactions.userId })
+			.from(reactions)
+			.where(and(eq(reactions.articleId, articleId), eq(reactions.userId, currentUser.id)))
+			.limit(1);
+		reacted = userReaction.length > 0;
+	}
+
+	return new Response(JSON.stringify({ count: countResult?.count ?? 0, reacted }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export async function POST(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	const articleRow = await db
+		.select({ id: articles.id })
+		.from(articles)
+		.where(eq(articles.slug, slug))
+		.limit(1);
+
+	if (articleRow.length === 0) {
+		return notFound('Article not found');
+	}
+
+	const articleId = articleRow[0].id;
+
+	const existing = await db
+		.select({ userId: reactions.userId })
+		.from(reactions)
+		.where(and(eq(reactions.articleId, articleId), eq(reactions.userId, currentUser.id)))
+		.limit(1);
+
+	if (existing.length > 0) {
+		await db
+			.delete(reactions)
+			.where(and(eq(reactions.articleId, articleId), eq(reactions.userId, currentUser.id)));
+	} else {
+		await db.insert(reactions).values({
+			articleId,
+			userId: currentUser.id,
+		});
+	}
+
+	const reacted = existing.length === 0;
+
+	const [countResult] = await db
+		.select({ count: count() })
+		.from(reactions)
+		.where(eq(reactions.articleId, articleId));
+
+	return new Response(JSON.stringify({ reacted, count: countResult?.count ?? 0 }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/src/pages/api/articles/index.ts
+++ b/src/pages/api/articles/index.ts
@@ -22,7 +22,14 @@ export async function GET(context: APIContext): Promise<Response> {
 		status = 'published';
 	}
 
-	const result = await listArticles(db, { page, limit, tag, status });
+	const validSorts = ['newest', 'popular'] as const;
+	const rawSort = params.get('sort');
+	const sort: (typeof validSorts)[number] =
+		rawSort && validSorts.includes(rawSort as (typeof validSorts)[number])
+			? (rawSort as (typeof validSorts)[number])
+			: 'newest';
+
+	const result = await listArticles(db, { page, limit, tag, status, sort });
 
 	return new Response(JSON.stringify(result), {
 		status: 200,

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -1,5 +1,8 @@
 ---
+import { and, count as countFn, eq } from 'drizzle-orm';
 import ArticleContent from '../../components/ArticleContent.astro';
+import ReactionButton from '../../components/ReactionButton.tsx';
+import { reactions } from '../../db/schema';
 import Layout from '../../layouts/Layout.astro';
 import { getArticleBySlug } from '../../lib/articles';
 import { renderMarkdown } from '../../lib/markdown';
@@ -17,6 +20,25 @@ const description = article.body
 	.replace(/[#*`~>[\]()!_-]/g, '')
 	.replace(/\n/g, ' ')
 	.slice(0, 120);
+
+// リアクション数を取得
+const [reactionResult] = await Astro.locals.db
+	.select({ count: countFn() })
+	.from(reactions)
+	.where(eq(reactions.articleId, article.id));
+const reactionCount = reactionResult?.count ?? 0;
+
+// ログインユーザーのリアクション状態を取得
+const currentUser = Astro.locals.currentUser;
+let reacted = false;
+if (currentUser) {
+	const [userReaction] = await Astro.locals.db
+		.select({ articleId: reactions.articleId })
+		.from(reactions)
+		.where(and(eq(reactions.articleId, article.id), eq(reactions.userId, currentUser.id)))
+		.limit(1);
+	reacted = !!userReaction;
+}
 ---
 
 <Layout title={article.title} description={description}>
@@ -61,5 +83,15 @@ const description = article.body
 		</header>
 
 		<ArticleContent html={html} />
+
+		<div class="mt-8 flex justify-start">
+			<ReactionButton
+				client:load
+				slug={article.slug}
+				initialCount={reactionCount}
+				initialReacted={reacted}
+				isAuthenticated={!!currentUser}
+			/>
+		</div>
 	</article>
 </Layout>


### PR DESCRIPTION
## Summary

- `POST/GET /api/articles/[slug]/reactions` エンドポイントを新規追加（リアクションのトグル・状態取得）
- 記事一覧API に `sort=popular` パラメータを追加（リアクション数降順ソート）
- `ReactionButton` Reactコンポーネントを実装（楽観的更新、未認証時のログイン誘導）
- 記事詳細ページにリアクションボタンを配置

## 実装詳細

### バックエンド
- **リアクションAPI**: 認証ユーザーのトグル操作、カウント取得（未認証でも可）
- **人気順ソート**: reactions テーブルを LEFT JOIN → COUNT で集計 → 降順ソート

### フロントエンド
- **ReactionButton**: 👍 {count} ボタン、リアクション済み/未済のスタイル切り替え
- **楽観的更新**: クリック時に即座にUI更新、API応答後に同期、エラー時はロールバック
- **未認証対応**: クリック時に「ログインしてリアクション」リンクを表示

## Test plan

- [ ] `pnpm astro check` がエラーなく通ること ✅
- [ ] `pnpm biome check .` がエラーなく通ること ✅
- [ ] 認証済みユーザーで記事にリアクション（👍）できること
- [ ] 同じ記事に再度クリックでリアクション解除（トグル動作）
- [ ] 未認証ユーザーがボタンクリック時にログイン誘導が表示されること
- [ ] `GET /api/articles?sort=popular` でリアクション数順にソートされること
- [ ] `GET /api/articles/[slug]/reactions` でリアクション数と自分の状態が取得できること

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)