### PR TITLE
feat: ユーザープロフィール編集機能を実装 (#47)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -34,6 +34,7 @@ const currentUser = Astro.locals.currentUser;
 							<UserMenu
 								client:load
 								displayName={currentUser.profile?.displayName ?? currentUser.email}
+								avatarUrl={currentUser.profile?.avatarUrl ?? undefined}
 							/>
 						</>
 					) : (
@@ -51,7 +52,10 @@ const currentUser = Astro.locals.currentUser;
 			<!-- Mobile Navigation -->
 			<MobileNav
 				client:load
-				user={currentUser ? { displayName: currentUser.profile?.displayName ?? currentUser.email } : null}
+				user={currentUser ? {
+					displayName: currentUser.profile?.displayName ?? currentUser.email,
+					avatarUrl: currentUser.profile?.avatarUrl ?? undefined,
+				} : null}
 			/>
 		</div>
 	</div>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,8 +1,8 @@
-import { LogOut, Menu, X } from 'lucide-react';
+import { LogOut, Menu, Settings, User, X } from 'lucide-react';
 import { useState } from 'react';
 
 interface Props {
-	user: { displayName: string } | null;
+	user: { displayName: string; avatarUrl?: string } | null;
 }
 
 export default function MobileNav({ user }: Props) {
@@ -38,7 +38,28 @@ export default function MobileNav({ user }: Props) {
 								>
 									投稿
 								</a>
-								<span className="text-foreground text-sm py-2">{user.displayName}</span>
+								<div className="flex items-center gap-2 py-2">
+									{user.avatarUrl ? (
+										<img
+											src={user.avatarUrl}
+											alt=""
+											className="w-7 h-7 rounded-full object-cover"
+										/>
+									) : (
+										<div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+											<User size={14} className="text-muted-foreground" />
+										</div>
+									)}
+									<span className="text-foreground text-sm">{user.displayName}</span>
+								</div>
+								<a
+									href="/settings/profile"
+									className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors py-2"
+									onClick={() => setIsOpen(false)}
+								>
+									<Settings size={16} />
+									プロフィール設定
+								</a>
 								<form method="POST" action="/api/auth/logout">
 									<button
 										type="submit"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,11 +1,12 @@
-import { ChevronDown, LogOut } from 'lucide-react';
+import { ChevronDown, LogOut, Settings, User } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 interface Props {
 	displayName: string;
+	avatarUrl?: string;
 }
 
-export default function UserMenu({ displayName }: Props) {
+export default function UserMenu({ displayName, avatarUrl }: Props) {
 	const [isOpen, setIsOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
 
@@ -24,18 +25,32 @@ export default function UserMenu({ displayName }: Props) {
 			<button
 				type="button"
 				onClick={() => setIsOpen(!isOpen)}
-				className="flex items-center gap-1 text-foreground text-sm hover:text-primary transition-colors"
+				className="flex items-center gap-2 text-foreground text-sm hover:text-primary transition-colors"
 			>
+				{avatarUrl ? (
+					<img src={avatarUrl} alt="" className="w-7 h-7 rounded-full object-cover" />
+				) : (
+					<div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+						<User size={14} className="text-muted-foreground" />
+					</div>
+				)}
 				{displayName}
 				<ChevronDown size={16} className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
 			</button>
 
 			{isOpen && (
 				<div className="absolute right-0 mt-2 w-48 bg-card border border-border rounded-md shadow-lg z-50">
+					<a
+						href="/settings/profile"
+						className="w-full flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors rounded-t-md"
+					>
+						<Settings size={16} />
+						プロフィール設定
+					</a>
 					<form method="POST" action="/api/auth/logout">
 						<button
 							type="submit"
-							className="w-full flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors rounded-md"
+							className="w-full flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors rounded-b-md"
 						>
 							<LogOut size={16} />
 							ログアウト

--- a/src/components/auth/OnboardingForm.tsx
+++ b/src/components/auth/OnboardingForm.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { Camera, User } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -7,6 +8,7 @@ import { Label } from '@/components/ui/label';
 interface OnboardingFormProps {
 	error?: string;
 	defaultDisplayName?: string;
+	defaultAvatarUrl?: string;
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -16,11 +18,20 @@ const ERROR_MESSAGES: Record<string, string> = {
 	username_taken: 'このユーザー名は既に使用されています。',
 };
 
-export function OnboardingForm({ error, defaultDisplayName }: OnboardingFormProps) {
+export function OnboardingForm({
+	error,
+	defaultDisplayName,
+	defaultAvatarUrl,
+}: OnboardingFormProps) {
 	const [username, setUsername] = useState('');
 	const [usernameStatus, setUsernameStatus] = useState<
 		'idle' | 'checking' | 'available' | 'taken' | 'invalid'
 	>('idle');
+	const [previewUrl, setPreviewUrl] = useState<string | undefined>(defaultAvatarUrl);
+	const [avatarUrl, setAvatarUrl] = useState(defaultAvatarUrl ?? '');
+	const [uploading, setUploading] = useState(false);
+	const [uploadError, setUploadError] = useState<string | undefined>();
+	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const checkUsername = useCallback(async (value: string) => {
 		if (!/^[a-zA-Z0-9_]{3,20}$/.test(value)) {
@@ -49,6 +60,58 @@ export function OnboardingForm({ error, defaultDisplayName }: OnboardingFormProp
 		return () => clearTimeout(timer);
 	}, [username, checkUsername]);
 
+	const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		if (file.size > 5 * 1024 * 1024) {
+			setUploadError('ファイルサイズは5MB以下にしてください');
+			return;
+		}
+
+		setUploadError(undefined);
+		const localPreview = URL.createObjectURL(file);
+		setPreviewUrl(localPreview);
+		setUploading(true);
+
+		try {
+			const res = await fetch('/api/images/upload', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					filename: file.name,
+					contentType: file.type,
+					size: file.size,
+				}),
+			});
+
+			if (!res.ok) {
+				const errorData = await res.json();
+				throw new Error(errorData.error?.message ?? 'アップロードURLの取得に失敗しました');
+			}
+
+			const { uploadUrl, imageUrl } = await res.json();
+
+			const putRes = await fetch(uploadUrl, {
+				method: 'PUT',
+				headers: { 'Content-Type': file.type },
+				body: file,
+			});
+
+			if (!putRes.ok) {
+				throw new Error('画像のアップロードに失敗しました');
+			}
+
+			setAvatarUrl(imageUrl);
+		} catch (err) {
+			setUploadError(err instanceof Error ? err.message : 'アップロードに失敗しました');
+			setPreviewUrl(defaultAvatarUrl);
+		} finally {
+			setUploading(false);
+			URL.revokeObjectURL(localPreview);
+		}
+	};
+
 	return (
 		<div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4">
 			<Card className="w-full max-w-md">
@@ -64,6 +127,39 @@ export function OnboardingForm({ error, defaultDisplayName }: OnboardingFormProp
 					)}
 
 					<form action="/api/auth/setup-profile" method="POST" className="space-y-4">
+						<div className="space-y-2">
+							<Label>アバター</Label>
+							<div className="flex items-center gap-4">
+								{previewUrl ? (
+									<img src={previewUrl} alt="" className="w-16 h-16 rounded-full object-cover" />
+								) : (
+									<div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+										<User size={24} className="text-muted-foreground" />
+									</div>
+								)}
+								<div>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										disabled={uploading}
+										onClick={() => fileInputRef.current?.click()}
+									>
+										<Camera size={16} className="mr-1" />
+										{uploading ? 'アップロード中...' : '画像を変更'}
+									</Button>
+									<input
+										ref={fileInputRef}
+										type="file"
+										accept="image/png,image/jpeg,image/webp,image/gif"
+										className="hidden"
+										onChange={handleFileSelect}
+									/>
+								</div>
+							</div>
+							{uploadError && <p className="text-xs text-destructive">{uploadError}</p>}
+							<input type="hidden" name="avatarUrl" value={avatarUrl} />
+						</div>
 						<div className="space-y-2">
 							<Label htmlFor="username">ユーザー名</Label>
 							<Input
@@ -102,7 +198,11 @@ export function OnboardingForm({ error, defaultDisplayName }: OnboardingFormProp
 								required
 							/>
 						</div>
-						<Button type="submit" className="w-full" disabled={usernameStatus !== 'available'}>
+						<Button
+							type="submit"
+							className="w-full"
+							disabled={usernameStatus !== 'available' || uploading}
+						>
 							設定を完了
 						</Button>
 					</form>

--- a/src/components/settings/ProfileEditForm.tsx
+++ b/src/components/settings/ProfileEditForm.tsx
@@ -1,0 +1,259 @@
+import { Camera, Loader2 } from 'lucide-react';
+import { type ChangeEvent, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface ProfileEditFormProps {
+	currentDisplayName: string;
+	currentAvatarUrl?: string;
+}
+
+export function ProfileEditForm({ currentDisplayName, currentAvatarUrl }: ProfileEditFormProps) {
+	const [displayName, setDisplayName] = useState(currentDisplayName);
+	const [avatarUrl, setAvatarUrl] = useState(currentAvatarUrl ?? '');
+	const [avatarPreview, setAvatarPreview] = useState(currentAvatarUrl ?? '');
+	const [savedDisplayName, setSavedDisplayName] = useState(currentDisplayName);
+	const [savedAvatarUrl, setSavedAvatarUrl] = useState(currentAvatarUrl ?? '');
+	const [isUploading, setIsUploading] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const [message, setMessage] = useState<{
+		type: 'success' | 'error';
+		text: string;
+	} | null>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleAvatarClick = () => {
+		fileInputRef.current?.click();
+	};
+
+	const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		// Show local preview immediately
+		const localPreview = URL.createObjectURL(file);
+		setAvatarPreview(localPreview);
+
+		setIsUploading(true);
+		setMessage(null);
+
+		try {
+			// Step 1: Get upload URL from the upload API
+			const uploadRes = await fetch('/api/images/upload', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					filename: file.name,
+					contentType: file.type,
+					size: file.size,
+				}),
+			});
+
+			if (!uploadRes.ok) {
+				const errorData = await uploadRes.json();
+				throw new Error(errorData.error?.message ?? 'Failed to get upload URL');
+			}
+
+			const { uploadUrl, imageUrl } = await uploadRes.json();
+
+			// Step 2: Upload the file to the signed URL
+			const putRes = await fetch(uploadUrl, {
+				method: 'PUT',
+				headers: { 'Content-Type': file.type },
+				body: file,
+			});
+
+			if (!putRes.ok) {
+				throw new Error('Failed to upload image');
+			}
+
+			// Step 3: Store the image URL for saving
+			setAvatarUrl(imageUrl);
+			setAvatarPreview(imageUrl);
+		} catch (err) {
+			setMessage({
+				type: 'error',
+				text: err instanceof Error ? err.message : '画像のアップロードに失敗しました。',
+			});
+			// Revert preview on error
+			setAvatarPreview(currentAvatarUrl ?? '');
+		} finally {
+			setIsUploading(false);
+			// Revoke object URL to free memory
+			URL.revokeObjectURL(localPreview);
+		}
+	};
+
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		setIsSaving(true);
+		setMessage(null);
+
+		const trimmed = displayName.trim();
+		if (trimmed.length < 1 || trimmed.length > 50) {
+			setMessage({
+				type: 'error',
+				text: '表示名は1〜50文字で入力してください。',
+			});
+			setIsSaving(false);
+			return;
+		}
+
+		const body: Record<string, string> = {};
+
+		if (trimmed !== savedDisplayName) {
+			body.displayName = trimmed;
+		}
+
+		if (avatarUrl && avatarUrl !== savedAvatarUrl) {
+			body.avatarUrl = avatarUrl;
+		}
+
+		if (Object.keys(body).length === 0) {
+			setMessage({
+				type: 'error',
+				text: '変更がありません。',
+			});
+			setIsSaving(false);
+			return;
+		}
+
+		try {
+			const res = await fetch('/api/auth/update-profile', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+			});
+
+			if (!res.ok) {
+				const errorData = await res.json();
+				throw new Error(errorData.error?.message ?? 'プロフィールの更新に失敗しました。');
+			}
+
+			if (body.displayName) setSavedDisplayName(body.displayName);
+			if (body.avatarUrl) setSavedAvatarUrl(body.avatarUrl);
+			setMessage({
+				type: 'success',
+				text: 'プロフィールを更新しました。',
+			});
+		} catch (err) {
+			setMessage({
+				type: 'error',
+				text: err instanceof Error ? err.message : 'プロフィールの更新に失敗しました。',
+			});
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4">
+			<Card className="w-full max-w-md">
+				<CardHeader>
+					<CardTitle className="text-2xl">プロフィール編集</CardTitle>
+					<CardDescription>表示名やアバターを変更できます</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{message && (
+						<div
+							className={`mb-4 rounded-md p-3 text-sm ${
+								message.type === 'success'
+									? 'bg-green-500/10 text-green-600'
+									: 'bg-destructive/10 text-destructive'
+							}`}
+						>
+							{message.text}
+						</div>
+					)}
+
+					<form onSubmit={handleSubmit} className="space-y-6">
+						{/* Avatar section */}
+						<div className="space-y-2">
+							<Label>アバター</Label>
+							<div className="flex items-center gap-4">
+								<button
+									type="button"
+									onClick={handleAvatarClick}
+									disabled={isUploading}
+									className="relative h-20 w-20 overflow-hidden rounded-full border-2 border-muted bg-muted hover:border-primary transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+								>
+									{avatarPreview ? (
+										<img
+											src={avatarPreview}
+											alt="アバター"
+											className="h-full w-full object-cover"
+										/>
+									) : (
+										<div className="flex h-full w-full items-center justify-center text-muted-foreground">
+											<Camera className="h-8 w-8" />
+										</div>
+									)}
+									{isUploading && (
+										<div className="absolute inset-0 flex items-center justify-center bg-background/60">
+											<Loader2 className="h-6 w-6 animate-spin" />
+										</div>
+									)}
+								</button>
+								<div className="flex flex-col gap-1">
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={handleAvatarClick}
+										disabled={isUploading}
+									>
+										{isUploading ? (
+											<>
+												<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+												アップロード中...
+											</>
+										) : (
+											'画像を選択'
+										)}
+									</Button>
+									<p className="text-xs text-muted-foreground">PNG, JPG, WebP, GIF（最大5MB）</p>
+								</div>
+							</div>
+							<input
+								ref={fileInputRef}
+								type="file"
+								accept="image/png,image/jpeg,image/webp,image/gif"
+								className="hidden"
+								onChange={handleFileChange}
+							/>
+						</div>
+
+						{/* Display name section */}
+						<div className="space-y-2">
+							<Label htmlFor="displayName">表示名</Label>
+							<Input
+								id="displayName"
+								type="text"
+								placeholder="表示名"
+								value={displayName}
+								onChange={(e) => setDisplayName(e.target.value)}
+								required
+								minLength={1}
+								maxLength={50}
+							/>
+							<p className="text-xs text-muted-foreground">1〜50文字で入力してください</p>
+						</div>
+
+						<Button type="submit" className="w-full" disabled={isSaving || isUploading}>
+							{isSaving ? (
+								<>
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									保存中...
+								</>
+							) : (
+								'変更を保存'
+							)}
+						</Button>
+					</form>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/src/pages/api/auth/setup-profile.ts
+++ b/src/pages/api/auth/setup-profile.ts
@@ -39,7 +39,21 @@ export const POST: APIRoute = async (context) => {
 		return context.redirect('/onboarding?error=username_taken');
 	}
 
-	const avatarUrl = user.user_metadata?.avatar_url ?? null;
+	const rawAvatarUrl = formData.get('avatarUrl')?.toString()?.trim() || null;
+	let customAvatarUrl: string | null = null;
+	if (rawAvatarUrl) {
+		try {
+			const parsed = new URL(rawAvatarUrl);
+			if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+				customAvatarUrl = rawAvatarUrl;
+			}
+		} catch {
+			if (rawAvatarUrl.startsWith('/api/images/')) {
+				customAvatarUrl = rawAvatarUrl;
+			}
+		}
+	}
+	const avatarUrl = customAvatarUrl || user.user_metadata?.avatar_url || null;
 
 	await db.insert(profiles).values({
 		id: user.id,

--- a/src/pages/api/auth/update-profile.ts
+++ b/src/pages/api/auth/update-profile.ts
@@ -1,0 +1,107 @@
+import type { APIContext } from 'astro';
+import { eq } from 'drizzle-orm';
+import { profiles } from '../../../db/schema';
+import { errorResponse, unauthorized, validationError } from '../../../lib/errors';
+
+export async function POST(context: APIContext): Promise<Response> {
+	const { currentUser } = context.locals;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (!currentUser.profile) {
+		return errorResponse(
+			400,
+			'VALIDATION_ERROR',
+			'Profile not found. Please complete onboarding first.',
+		);
+	}
+
+	let body: unknown;
+	try {
+		body = await context.request.json();
+	} catch {
+		return errorResponse(400, 'VALIDATION_ERROR', 'Invalid JSON body');
+	}
+
+	if (typeof body !== 'object' || body === null) {
+		return errorResponse(400, 'VALIDATION_ERROR', 'Request body must be a JSON object');
+	}
+
+	const obj = body as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	const updates: Partial<{ displayName: string; avatarUrl: string }> = {};
+
+	if (obj.displayName !== undefined) {
+		if (typeof obj.displayName !== 'string') {
+			errors.displayName = ['displayName must be a string'];
+		} else {
+			const trimmed = obj.displayName.trim();
+			if (trimmed.length < 1 || trimmed.length > 50) {
+				errors.displayName = ['displayName must be between 1 and 50 characters'];
+			} else {
+				updates.displayName = trimmed;
+			}
+		}
+	}
+
+	if (obj.avatarUrl !== undefined) {
+		if (typeof obj.avatarUrl !== 'string') {
+			errors.avatarUrl = ['avatarUrl must be a string'];
+		} else {
+			try {
+				const parsed = new URL(obj.avatarUrl);
+				if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+					errors.avatarUrl = ['avatarUrl must be an HTTP(S) URL'];
+				} else {
+					updates.avatarUrl = obj.avatarUrl;
+				}
+			} catch {
+				// 相対パス（/api/images/... 等）も許可
+				if (obj.avatarUrl.startsWith('/api/images/')) {
+					updates.avatarUrl = obj.avatarUrl;
+				} else {
+					errors.avatarUrl = ['avatarUrl must be a valid URL or internal image path'];
+				}
+			}
+		}
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return validationError(errors);
+	}
+
+	if (Object.keys(updates).length === 0) {
+		return errorResponse(400, 'VALIDATION_ERROR', 'At least one field must be provided');
+	}
+
+	const { db } = context.locals;
+
+	const [updated] = await db
+		.update(profiles)
+		.set({
+			...updates,
+			updatedAt: new Date(),
+		})
+		.where(eq(profiles.id, currentUser.id))
+		.returning({
+			displayName: profiles.displayName,
+			avatarUrl: profiles.avatarUrl,
+		});
+
+	return new Response(
+		JSON.stringify({
+			success: true,
+			profile: {
+				displayName: updated.displayName,
+				avatarUrl: updated.avatarUrl,
+			},
+		}),
+		{
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		},
+	);
+}

--- a/src/pages/onboarding.astro
+++ b/src/pages/onboarding.astro
@@ -21,5 +21,10 @@ const defaultDisplayName = user?.user_metadata?.full_name ?? user?.user_metadata
 ---
 
 <Layout title="プロフィール設定">
-	<OnboardingForm error={error} defaultDisplayName={defaultDisplayName} client:load />
+	<OnboardingForm
+		error={error}
+		defaultDisplayName={defaultDisplayName}
+		defaultAvatarUrl={user?.user_metadata?.avatar_url ?? undefined}
+		client:load
+	/>
 </Layout>

--- a/src/pages/settings/profile.astro
+++ b/src/pages/settings/profile.astro
@@ -1,0 +1,22 @@
+---
+import { ProfileEditForm } from '../../components/settings/ProfileEditForm';
+import Layout from '../../layouts/Layout.astro';
+
+const currentUser = Astro.locals.currentUser;
+
+if (!currentUser) {
+	return Astro.redirect('/login');
+}
+
+if (!currentUser.profile) {
+	return Astro.redirect('/onboarding');
+}
+---
+
+<Layout title="プロフィール設定">
+	<ProfileEditForm
+		client:load
+		currentDisplayName={currentUser.profile.displayName}
+		currentAvatarUrl={currentUser.profile.avatarUrl ?? undefined}
+	/>
+</Layout>


### PR DESCRIPTION
## Summary
- ログイン後にいつでも表示名・アバター画像を変更できるプロフィール設定ページ (`/settings/profile`) を追加
- オンボーディング時にもアバター画像をカスタムアップロードできるように拡張（デフォルトはGoogleアバター）
- UserMenu / MobileNav にアバター表示と「プロフィール設定」リンクを追加

### 変更内容
- **新規**: `src/pages/settings/profile.astro` — 設定ページ
- **新規**: `src/components/settings/ProfileEditForm.tsx` — プロフィール編集フォーム（アバターアップロード付き）
- **新規**: `src/pages/api/auth/update-profile.ts` — プロフィール更新API
- **修正**: `src/components/auth/OnboardingForm.tsx` — アバターアップロード機能追加
- **修正**: `src/pages/api/auth/setup-profile.ts` — カスタムアバターURL対応 + URLバリデーション
- **修正**: `src/components/UserMenu.tsx` — アバター表示 + 設定リンク
- **修正**: `src/components/MobileNav.tsx` — アバター表示 + 設定リンク
- **修正**: `src/components/Header.astro` — avatarUrl prop追加

Closes #47

## Test plan
- [ ] ログイン後、ヘッダーのユーザーメニューからプロフィール設定ページに遷移できること
- [ ] 設定ページで表示名を変更し保存できること
- [ ] 設定ページでアバター画像をアップロード・変更できること
- [ ] オンボーディング時にアバター画像をアップロードできること
- [ ] オンボーディング時にアバターを変更しない場合、Googleアバターが使用されること
- [ ] モバイルナビゲーションでもプロフィール設定リンクとアバターが表示されること
- [ ] 不正なURL（javascript:等）がavatarUrlとして受け付けられないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)