### PR TITLE
feat: 記事一覧ページの実装 (#51)

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,139 @@
+---
+interface Props {
+	currentPage: number;
+	totalPages: number;
+	baseUrl: string; // 例: "/articles?sort=newest&tag=extreme"
+}
+
+const { currentPage, totalPages, baseUrl } = Astro.props;
+
+function buildPageUrl(baseUrl: string, page: number): string {
+	const url = new URL(baseUrl, 'http://dummy');
+	url.searchParams.set('page', String(page));
+	return url.pathname + url.search;
+}
+
+function getPageNumbers(current: number, total: number): (number | '...')[] {
+	if (total <= 5) {
+		return Array.from({ length: total }, (_, i) => i + 1);
+	}
+
+	const pages: (number | '...')[] = [];
+
+	// Always include page 1
+	pages.push(1);
+
+	// Calculate the range around the current page
+	const rangeStart = Math.max(2, current - 1);
+	const rangeEnd = Math.min(total - 1, current + 1);
+
+	// Add ellipsis before range if needed
+	if (rangeStart > 2) {
+		pages.push('...');
+	}
+
+	// Add pages in range
+	for (let i = rangeStart; i <= rangeEnd; i++) {
+		pages.push(i);
+	}
+
+	// Add ellipsis after range if needed
+	if (rangeEnd < total - 1) {
+		pages.push('...');
+	}
+
+	// Always include last page
+	pages.push(total);
+
+	return pages;
+}
+
+const pageNumbers = getPageNumbers(currentPage, totalPages);
+const hasPrev = currentPage > 1;
+const hasNext = currentPage < totalPages;
+---
+
+{totalPages > 1 && (
+	<nav aria-label="ページネーション" class="flex items-center justify-center gap-1">
+		{/* 前へボタン */}
+		{hasPrev ? (
+			<a
+				href={buildPageUrl(baseUrl, currentPage - 1)}
+				class="inline-flex items-center justify-center h-9 px-3 rounded-md text-sm font-medium
+					text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+				aria-label="前のページ"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="m15 18-6-6 6-6" />
+				</svg>
+				<span class="ml-1 hidden sm:inline">前へ</span>
+			</a>
+		) : (
+			<span
+				class="inline-flex items-center justify-center h-9 px-3 rounded-md text-sm font-medium
+					text-muted-foreground opacity-50 pointer-events-none"
+				aria-disabled="true"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="m15 18-6-6 6-6" />
+				</svg>
+				<span class="ml-1 hidden sm:inline">前へ</span>
+			</span>
+		)}
+
+		{/* ページ番号 */}
+		{pageNumbers.map((page) =>
+			page === '...' ? (
+				<span class="inline-flex items-center justify-center size-9 text-sm text-muted-foreground">
+					...
+				</span>
+			) : page === currentPage ? (
+				<span
+					class="inline-flex items-center justify-center size-9 rounded-md text-sm font-medium
+						bg-primary text-primary-foreground"
+					aria-current="page"
+				>
+					{page}
+				</span>
+			) : (
+				<a
+					href={buildPageUrl(baseUrl, page)}
+					class="inline-flex items-center justify-center size-9 rounded-md text-sm font-medium
+						text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+				>
+					{page}
+				</a>
+			)
+		)}
+
+		{/* 次へボタン */}
+		{hasNext ? (
+			<a
+				href={buildPageUrl(baseUrl, currentPage + 1)}
+				class="inline-flex items-center justify-center h-9 px-3 rounded-md text-sm font-medium
+					text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+				aria-label="次のページ"
+			>
+				<span class="mr-1 hidden sm:inline">次へ</span>
+				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="m9 18 6-6-6-6" />
+				</svg>
+			</a>
+		) : (
+			<span
+				class="inline-flex items-center justify-center h-9 px-3 rounded-md text-sm font-medium
+					text-muted-foreground opacity-50 pointer-events-none"
+				aria-disabled="true"
+			>
+				<span class="mr-1 hidden sm:inline">次へ</span>
+				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="m9 18 6-6-6-6" />
+				</svg>
+			</span>
+		)}
+	</nav>
+)}

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -1,0 +1,177 @@
+---
+import ArticleCard from '../../components/ArticleCard.astro';
+import Pagination from '../../components/Pagination.astro';
+import Layout from '../../layouts/Layout.astro';
+import { listArticles } from '../../lib/articles';
+import { listTags } from '../../lib/tags';
+
+const page = Math.max(1, Number(Astro.url.searchParams.get('page')) || 1);
+const sortParam = Astro.url.searchParams.get('sort');
+const sort = sortParam === 'popular' ? 'popular' : 'newest';
+const tag = Astro.url.searchParams.get('tag') || undefined;
+
+const { data: articles, meta } = await listArticles(Astro.locals.db, {
+	page,
+	limit: 12,
+	sort,
+	tag,
+	status: 'published',
+});
+
+const allTags = await listTags(Astro.locals.db);
+const totalPages = Math.ceil(meta.total / meta.limit);
+
+const selectedTag = tag ? allTags.find((t) => t.slug === tag) : undefined;
+const pageTitle = selectedTag ? `タグ: ${selectedTag.name}の記事` : '記事一覧';
+
+const baseUrl = `/articles?sort=${sort}${tag ? `&tag=${encodeURIComponent(tag)}` : ''}`;
+
+function sortUrl(sortValue: 'newest' | 'popular'): string {
+	return `/articles?sort=${sortValue}${tag ? `&tag=${encodeURIComponent(tag)}` : ''}`;
+}
+
+function tagUrl(tagSlug: string | null): string {
+	if (tagSlug) {
+		return `/articles?sort=${sort}&tag=${encodeURIComponent(tagSlug)}`;
+	}
+	return `/articles?sort=${sort}`;
+}
+
+const TAG_DISPLAY_LIMIT = 12;
+const showExpandButton = allTags.length > TAG_DISPLAY_LIMIT;
+---
+
+<Layout title={pageTitle} description={`XIVPedia - ${pageTitle}`}>
+	<section class="py-8">
+		<h1 class="text-3xl font-bold text-foreground">{pageTitle}</h1>
+
+		{/* Sort tabs and tag filter */}
+		<div class="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+			<div class="flex items-center gap-2">
+				<a
+					href={sortUrl('newest')}
+					class:list={[
+						'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
+						sort === 'newest'
+							? 'bg-primary text-primary-foreground border-primary'
+							: 'bg-card text-muted-foreground border-border hover:text-foreground',
+					]}
+				>
+					新着順
+				</a>
+				<a
+					href={sortUrl('popular')}
+					class:list={[
+						'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
+						sort === 'popular'
+							? 'bg-primary text-primary-foreground border-primary'
+							: 'bg-card text-muted-foreground border-border hover:text-foreground',
+					]}
+				>
+					人気順
+				</a>
+			</div>
+		</div>
+
+		{/* Tag filter */}
+		{allTags.length > 0 && (
+			<div class="mt-4">
+				<div class="flex items-center gap-2 mb-2">
+					<span class="text-sm font-medium text-muted-foreground">タグ:</span>
+					{selectedTag && (
+						<a
+							href={tagUrl(null)}
+							class="inline-flex items-center gap-1 rounded-md bg-destructive/10 px-2 py-0.5 text-xs text-destructive hover:bg-destructive/20 transition-colors"
+						>
+							クリア
+						</a>
+					)}
+				</div>
+				<div id="tag-list" class="flex flex-wrap gap-2">
+					{allTags.slice(0, TAG_DISPLAY_LIMIT).map((t) => (
+						<a
+							href={tagUrl(t.slug)}
+							class:list={[
+								'inline-block rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+								tag === t.slug
+									? 'bg-primary text-primary-foreground'
+									: 'bg-secondary text-muted-foreground hover:text-foreground',
+							]}
+						>
+							{t.name}
+						</a>
+					))}
+					{showExpandButton && (
+						<>
+							{allTags.slice(TAG_DISPLAY_LIMIT).map((t) => (
+								<a
+									href={tagUrl(t.slug)}
+									class:list={[
+										'tag-extra hidden rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+										tag === t.slug
+											? 'bg-primary text-primary-foreground'
+											: 'bg-secondary text-muted-foreground hover:text-foreground',
+									]}
+								>
+									{t.name}
+								</a>
+							))}
+							<button
+								id="tag-expand-btn"
+								type="button"
+								class="inline-block rounded-md bg-secondary px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+							>
+								もっと見る
+							</button>
+						</>
+					)}
+				</div>
+			</div>
+		)}
+
+		{/* Article grid */}
+		{articles.length > 0 ? (
+			<div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{articles.map((article) => (
+					<ArticleCard
+						title={article.title}
+						slug={article.slug}
+						author={article.author}
+						tags={article.tags}
+						publishedAt={article.publishedAt}
+						createdAt={article.createdAt}
+					/>
+				))}
+			</div>
+		) : (
+			<div class="mt-8 rounded-lg border border-border bg-card p-12 text-center">
+				<p class="text-muted-foreground">記事が見つかりませんでした</p>
+			</div>
+		)}
+
+		{/* Pagination */}
+		{totalPages > 1 && (
+			<div class="mt-8">
+				<Pagination
+					currentPage={page}
+					totalPages={totalPages}
+					baseUrl={baseUrl}
+				/>
+			</div>
+		)}
+	</section>
+</Layout>
+
+<script>
+	const expandBtn = document.getElementById('tag-expand-btn');
+	if (expandBtn) {
+		expandBtn.addEventListener('click', () => {
+			const extras = document.querySelectorAll('.tag-extra');
+			for (const el of extras) {
+				el.classList.remove('hidden');
+				el.classList.add('inline-block');
+			}
+			expandBtn.remove();
+		});
+	}
+</script>


### PR DESCRIPTION
## Summary
- `/articles` で公開済み記事の一覧ページを実装
- 新着順/人気順のソート切り替え、タグフィルタ、ページネーションに対応
- 汎用 `Pagination.astro` コンポーネントを新規作成（#13, #12 でも再利用可能）

## 変更内容
- `src/pages/articles/index.astro` — 記事一覧ページ本体（SSR、クエリパラメータでソート・フィルタ・ページ制御）
- `src/components/Pagination.astro` — ページネーションコンポーネント（省略記号付きページ番号、前へ/次へボタン）

## 主な機能
- **ソート**: `?sort=newest`（デフォルト）/ `?sort=popular` でリアクション数順
- **タグフィルタ**: `?tag=<slug>` でタグ別絞り込み、「クリア」ボタンで解除
- **ページネーション**: `?page=N`、1ページ12件、省略記号付きページ番号
- **レスポンシブ**: モバイル1列 → タブレット2列 → デスクトップ3列
- **空状態**: 記事0件時に「記事が見つかりませんでした」を表示
- **セキュリティ**: sort パラメータのバリデーション、tag の encodeURIComponent、page の負数クランプ

Closes #51

## Test plan
- [ ] `/articles` にアクセスして記事一覧が表示されることを確認
- [ ] ソートタブ（新着順/人気順）の切り替えが正しく動作する
- [ ] タグをクリックして絞り込みが動作し、「クリア」で解除される
- [ ] ページネーションが正しく動作する（2ページ目以降への遷移）
- [ ] 記事0件時に空状態メッセージが表示される
- [ ] ヘッダーの「記事一覧」リンクから遷移できる
- [ ] モバイル/タブレット/デスクトップでレスポンシブ表示される
- [ ] `pnpm biome check .` がエラーなし
- [ ] `pnpm astro check` がエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)