### PR TITLE
feat: コメント機能（API + UI）を実装 (#10)

### DIFF
--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface Comment {
+	id: string;
+	body: string;
+	createdAt: string;
+	author: {
+		id: string;
+		displayName: string;
+		avatarUrl: string | null;
+	};
+}
+
+interface CommentSectionProps {
+	slug: string;
+	articleAuthorId: string;
+	currentUser: {
+		id: string;
+		displayName: string;
+		avatarUrl: string | null;
+		role: string;
+	} | null;
+}
+
+const PAGE_SIZE = 50;
+
+function formatRelativeTime(dateString: string): string {
+	const now = new Date();
+	const date = new Date(dateString);
+	const diffMs = now.getTime() - date.getTime();
+	const diffSeconds = Math.floor(diffMs / 1000);
+	const diffMinutes = Math.floor(diffSeconds / 60);
+	const diffHours = Math.floor(diffMinutes / 60);
+	const diffDays = Math.floor(diffHours / 24);
+	const diffMonths = Math.floor(diffDays / 30);
+	const diffYears = Math.floor(diffDays / 365);
+
+	if (diffSeconds < 60) {
+		return 'たった今';
+	}
+	if (diffMinutes < 60) {
+		return `${diffMinutes}分前`;
+	}
+	if (diffHours < 24) {
+		return `${diffHours}時間前`;
+	}
+	if (diffDays < 30) {
+		return `${diffDays}日前`;
+	}
+	if (diffMonths < 12) {
+		return `${diffMonths}ヶ月前`;
+	}
+	return `${diffYears}年前`;
+}
+
+export default function CommentSection({
+	slug,
+	articleAuthorId,
+	currentUser,
+}: CommentSectionProps) {
+	const [comments, setComments] = useState<Comment[]>([]);
+	const [total, setTotal] = useState(0);
+	const [isLoadingComments, setIsLoadingComments] = useState(true);
+	const [isLoadingMore, setIsLoadingMore] = useState(false);
+	const [body, setBody] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchComments = useCallback(
+		async (offset = 0) => {
+			try {
+				const res = await fetch(
+					`/api/articles/${slug}/comments?limit=${PAGE_SIZE}&offset=${offset}`,
+				);
+				if (!res.ok) {
+					throw new Error('コメントの取得に失敗しました');
+				}
+				const json = await res.json();
+				return json as { comments: Comment[]; total: number };
+			} catch {
+				setError('コメントの取得に失敗しました');
+				return null;
+			}
+		},
+		[slug],
+	);
+
+	const loadInitialComments = useCallback(async () => {
+		setIsLoadingComments(true);
+		const data = await fetchComments(0);
+		if (data) {
+			setComments(data.comments);
+			setTotal(data.total);
+			setError(null);
+		}
+		setIsLoadingComments(false);
+	}, [fetchComments]);
+
+	async function handleLoadMore() {
+		setIsLoadingMore(true);
+		const data = await fetchComments(comments.length);
+		if (data) {
+			setComments((prev) => [...prev, ...data.comments]);
+			setTotal(data.total);
+		}
+		setIsLoadingMore(false);
+	}
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+
+		const trimmedBody = body.trim();
+		if (!trimmedBody) {
+			setError('コメントを入力してください');
+			return;
+		}
+
+		setIsSubmitting(true);
+		setError(null);
+
+		try {
+			const res = await fetch(`/api/articles/${slug}/comments`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ body: trimmedBody }),
+			});
+
+			if (!res.ok) {
+				const json = await res.json().catch(() => null);
+				throw new Error(json?.error ?? 'コメントの投稿に失敗しました');
+			}
+
+			const newComment: Comment = await res.json();
+			setComments((prev) => [newComment, ...prev]);
+			setTotal((prev) => prev + 1);
+			setBody('');
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'コメントの投稿に失敗しました');
+		} finally {
+			setIsSubmitting(false);
+		}
+	}
+
+	async function handleDelete(commentId: string) {
+		if (!window.confirm('このコメントを削除しますか？')) {
+			return;
+		}
+
+		const prevComments = comments;
+		const prevTotal = total;
+
+		// 楽観的更新
+		setComments((prev) => prev.filter((c) => c.id !== commentId));
+		setTotal((prev) => prev - 1);
+
+		try {
+			const res = await fetch(`/api/articles/${slug}/comments/${commentId}`, { method: 'DELETE' });
+
+			if (!res.ok) {
+				// エラー時はUIを元に戻す
+				setComments(prevComments);
+				setTotal(prevTotal);
+				setError('コメントの削除に失敗しました');
+			}
+		} catch {
+			// ネットワークエラー時もUIを元に戻す
+			setComments(prevComments);
+			setTotal(prevTotal);
+			setError('コメントの削除に失敗しました');
+		}
+	}
+
+	function canDelete(comment: Comment): boolean {
+		if (!currentUser) return false;
+		if (currentUser.role === 'admin') return true;
+		if (currentUser.id === comment.author.id) return true;
+		if (currentUser.id === articleAuthorId) return true;
+		return false;
+	}
+
+	useEffect(() => {
+		loadInitialComments();
+	}, [loadInitialComments]);
+
+	const hasMore = comments.length < total;
+
+	return (
+		<section className="mt-10">
+			<h2 className="text-lg font-bold text-foreground">コメント ({total}件)</h2>
+
+			{error && (
+				<div className="mt-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+					{error}
+				</div>
+			)}
+
+			{/* コメント一覧 */}
+			<div className="mt-4 space-y-4">
+				{isLoadingComments ? (
+					<p className="text-sm text-muted-foreground">読み込み中...</p>
+				) : comments.length === 0 ? (
+					<p className="text-sm text-muted-foreground">まだコメントはありません</p>
+				) : (
+					comments.map((comment) => (
+						<div key={comment.id} className="rounded-lg border border-border bg-card p-4">
+							<div className="flex items-start justify-between gap-2">
+								<div className="flex items-center gap-2">
+									{comment.author.avatarUrl ? (
+										<img
+											src={comment.author.avatarUrl}
+											alt={comment.author.displayName}
+											className="h-8 w-8 rounded-full"
+											loading="lazy"
+										/>
+									) : (
+										<span className="flex h-8 w-8 items-center justify-center rounded-full bg-secondary text-sm font-medium">
+											{comment.author.displayName.charAt(0)}
+										</span>
+									)}
+									<span className="text-sm font-medium text-foreground">
+										{comment.author.displayName}
+									</span>
+									<span className="text-xs text-muted-foreground">
+										{formatRelativeTime(comment.createdAt)}
+									</span>
+								</div>
+								{canDelete(comment) && (
+									<button
+										type="button"
+										onClick={() => handleDelete(comment.id)}
+										className="text-xs text-muted-foreground transition-colors hover:text-destructive"
+									>
+										削除
+									</button>
+								)}
+							</div>
+							<p className="mt-2 whitespace-pre-wrap text-sm text-foreground">{comment.body}</p>
+						</div>
+					))
+				)}
+			</div>
+
+			{/* もっと読むボタン */}
+			{hasMore && (
+				<div className="mt-4 flex justify-center">
+					<button
+						type="button"
+						onClick={handleLoadMore}
+						disabled={isLoadingMore}
+						className="rounded-md border border-border bg-card px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						{isLoadingMore ? '読み込み中...' : 'もっと読む'}
+					</button>
+				</div>
+			)}
+
+			{/* コメント投稿フォーム / ログインリンク */}
+			<div className="mt-6">
+				{currentUser ? (
+					<form onSubmit={handleSubmit}>
+						<textarea
+							value={body}
+							onChange={(e) => setBody(e.target.value)}
+							placeholder="コメントを入力..."
+							rows={3}
+							className="w-full resize-none rounded-lg border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+						/>
+						<div className="mt-2 flex justify-end">
+							<button
+								type="submit"
+								disabled={isSubmitting || !body.trim()}
+								className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+							>
+								{isSubmitting ? '投稿中...' : '投稿する'}
+							</button>
+						</div>
+					</form>
+				) : (
+					<p className="text-sm text-muted-foreground">
+						<a href="/login" className="text-primary transition-colors hover:underline">
+							ログイン
+						</a>
+						してコメントする
+					</p>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -2,6 +2,10 @@ type ValidationSuccess<T> = { success: true; data: T };
 type ValidationFailure = { success: false; errors: Record<string, string[]> };
 type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
 
+export interface CreateCommentInput {
+	body: string;
+}
+
 export interface CreateArticleInput {
 	title: string;
 	body: string;
@@ -142,4 +146,33 @@ export function validateUpdateArticle(data: unknown): ValidationResult<UpdateArt
 	if (hasStatus) result.status = obj.status as 'draft' | 'published';
 
 	return { success: true, data: result };
+}
+
+export function validateCreateComment(data: unknown): ValidationResult<CreateCommentInput> {
+	if (typeof data !== 'object' || data === null) {
+		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
+	}
+
+	const obj = data as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	// body
+	if (obj.body === undefined || obj.body === null) {
+		errors.body = ['body is required'];
+	} else if (typeof obj.body !== 'string') {
+		errors.body = ['body must be a string'];
+	} else if (obj.body.length < 1 || obj.body.length > 2000) {
+		errors.body = ['body must be between 1 and 2000 characters'];
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { success: false, errors };
+	}
+
+	return {
+		success: true,
+		data: {
+			body: obj.body as string,
+		},
+	};
 }

--- a/src/pages/api/articles/[slug]/comments/[id].ts
+++ b/src/pages/api/articles/[slug]/comments/[id].ts
@@ -1,0 +1,46 @@
+import type { APIContext } from 'astro';
+import { eq } from 'drizzle-orm';
+import { articles, comments } from '../../../../../db/schema';
+import { forbidden, notFound, unauthorized } from '../../../../../lib/errors';
+
+export async function DELETE(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+	const commentId = context.params.id as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	const articleRow = await db
+		.select({ id: articles.id, authorId: articles.authorId })
+		.from(articles)
+		.where(eq(articles.slug, slug))
+		.limit(1);
+
+	if (articleRow.length === 0) {
+		return notFound('Article not found');
+	}
+
+	const commentRow = await db
+		.select({ id: comments.id, authorId: comments.authorId })
+		.from(comments)
+		.where(eq(comments.id, commentId))
+		.limit(1);
+
+	if (commentRow.length === 0) {
+		return notFound('Comment not found');
+	}
+
+	const isCommentAuthor = currentUser.id === commentRow[0].authorId;
+	const isArticleAuthor = currentUser.id === articleRow[0].authorId;
+	const isAdmin = currentUser.profile?.role === 'admin';
+
+	if (!isCommentAuthor && !isArticleAuthor && !isAdmin) {
+		return forbidden();
+	}
+
+	await db.delete(comments).where(eq(comments.id, commentId));
+
+	return new Response(null, { status: 204 });
+}

--- a/src/pages/api/articles/[slug]/comments/index.ts
+++ b/src/pages/api/articles/[slug]/comments/index.ts
@@ -1,0 +1,121 @@
+import type { APIContext } from 'astro';
+import { count, desc, eq } from 'drizzle-orm';
+import { articles, comments, profiles } from '../../../../../db/schema';
+import { notFound, unauthorized, validationError } from '../../../../../lib/errors';
+import { validateCreateComment } from '../../../../../lib/validation';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db } = context.locals;
+	const slug = context.params.slug as string;
+	const params = context.url.searchParams;
+
+	const limit = Math.min(Math.max(Number(params.get('limit') ?? '50'), 1), 100);
+	const offset = Math.max(Number(params.get('offset') ?? '0'), 0);
+
+	const articleRow = await db
+		.select({ id: articles.id })
+		.from(articles)
+		.where(eq(articles.slug, slug))
+		.limit(1);
+
+	if (articleRow.length === 0) {
+		return notFound('Article not found');
+	}
+
+	const articleId = articleRow[0].id;
+
+	const [totalResult] = await db
+		.select({ count: count() })
+		.from(comments)
+		.where(eq(comments.articleId, articleId));
+
+	const rows = await db
+		.select({
+			id: comments.id,
+			body: comments.body,
+			articleId: comments.articleId,
+			createdAt: comments.createdAt,
+			updatedAt: comments.updatedAt,
+			author: {
+				id: profiles.id,
+				displayName: profiles.displayName,
+				avatarUrl: profiles.avatarUrl,
+			},
+		})
+		.from(comments)
+		.innerJoin(profiles, eq(comments.authorId, profiles.id))
+		.where(eq(comments.articleId, articleId))
+		.orderBy(desc(comments.createdAt))
+		.limit(limit)
+		.offset(offset);
+
+	return new Response(JSON.stringify({ comments: rows, total: totalResult?.count ?? 0 }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export async function POST(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	let body: unknown;
+	try {
+		body = await context.request.json();
+	} catch {
+		return validationError({ _: ['Request body must be valid JSON'] });
+	}
+	const validation = validateCreateComment(body);
+
+	if (!validation.success) {
+		return validationError(validation.errors);
+	}
+
+	const articleRow = await db
+		.select({ id: articles.id })
+		.from(articles)
+		.where(eq(articles.slug, slug))
+		.limit(1);
+
+	if (articleRow.length === 0) {
+		return notFound('Article not found');
+	}
+
+	const articleId = articleRow[0].id;
+
+	const [inserted] = await db
+		.insert(comments)
+		.values({
+			body: validation.data.body,
+			articleId,
+			authorId: currentUser.id,
+		})
+		.returning();
+
+	const [commentWithAuthor] = await db
+		.select({
+			id: comments.id,
+			body: comments.body,
+			articleId: comments.articleId,
+			createdAt: comments.createdAt,
+			updatedAt: comments.updatedAt,
+			author: {
+				id: profiles.id,
+				displayName: profiles.displayName,
+				avatarUrl: profiles.avatarUrl,
+			},
+		})
+		.from(comments)
+		.innerJoin(profiles, eq(comments.authorId, profiles.id))
+		.where(eq(comments.id, inserted.id))
+		.limit(1);
+
+	return new Response(JSON.stringify(commentWithAuthor), {
+		status: 201,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { and, count as countFn, eq } from 'drizzle-orm';
 import ArticleContent from '../../components/ArticleContent.astro';
+import CommentSection from '../../components/comments/CommentSection.tsx';
 import ReactionButton from '../../components/ReactionButton.tsx';
 import { reactions } from '../../db/schema';
 import Layout from '../../layouts/Layout.astro';
@@ -93,5 +94,17 @@ if (currentUser) {
 				isAuthenticated={!!currentUser}
 			/>
 		</div>
+
+		<CommentSection
+			client:load
+			slug={article.slug}
+			articleAuthorId={article.author.id}
+			currentUser={currentUser ? {
+				id: currentUser.id,
+				displayName: currentUser.profile?.displayName ?? '',
+				avatarUrl: currentUser.profile?.avatarUrl ?? null,
+				role: currentUser.profile?.role ?? 'user',
+			} : null}
+		/>
 	</article>
 </Layout>


### PR DESCRIPTION
## Summary

- コメント一覧取得 API（`GET /api/articles/[slug]/comments`）：ページネーション対応、著者情報含む
- コメント投稿 API（`POST /api/articles/[slug]/comments`）：認証必須、1〜2000文字バリデーション
- コメント削除 API（`DELETE /api/articles/[slug]/comments/[id]`）：コメント著者・記事著者・admin のみ
- `CommentSection` React コンポーネント：一覧表示・投稿フォーム・削除・ページネーション・楽観的UI更新
- 記事詳細ページへの統合

Closes #10

## Test plan

- [ ] 記事詳細ページにコメントセクションが表示される
- [ ] 認証済みユーザーがコメントを投稿できる
- [ ] コメント著者・記事著者・admin がコメントを削除できる
- [ ] 未認証ユーザーにはログイン促進メッセージが表示される
- [ ] バリデーションエラー（空・2000文字超）が適切に表示される
- [ ] `pnpm exec biome check .` がエラーなく通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)