### PR TITLE
feat: トップページ・タグページ・マイページを実装 (#13)

### DIFF
--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -6,9 +6,10 @@ interface Props {
 	tags: { name: string; slug: string }[];
 	publishedAt: Date | null;
 	createdAt: Date;
+	reactionCount?: number;
 }
 
-const { title, slug, author, tags, publishedAt, createdAt } = Astro.props;
+const { title, slug, author, tags, publishedAt, createdAt, reactionCount } = Astro.props;
 const displayDate = (publishedAt ?? createdAt).toLocaleDateString('ja-JP');
 ---
 
@@ -42,6 +43,11 @@ const displayDate = (publishedAt ?? createdAt).toLocaleDateString('ja-JP');
 		<time datetime={(publishedAt ?? createdAt).toISOString()}>
 			{displayDate}
 		</time>
+		{reactionCount != null && reactionCount > 0 && (
+			<span class="ml-auto flex items-center gap-1">
+				👍 {reactionCount}
+			</span>
+		)}
 	</div>
 
 	{tags.length > 0 && (

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,9 +21,21 @@ const currentUser = Astro.locals.currentUser;
 				>
 					記事一覧
 				</a>
+				<a
+					href="/tags"
+					class="text-muted-foreground hover:text-foreground transition-colors"
+				>
+					タグ
+				</a>
 				{
 					currentUser ? (
 						<>
+							<a
+								href="/mypage"
+								class="text-muted-foreground hover:text-foreground transition-colors"
+							>
+								マイページ
+							</a>
 							<a
 								href="/articles/new"
 								class="bg-primary text-primary-foreground px-4 py-2 rounded-md

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -29,6 +29,13 @@ export default function MobileNav({ user }: Props) {
 						>
 							記事一覧
 						</a>
+						<a
+							href="/tags"
+							className="text-muted-foreground hover:text-foreground transition-colors py-2"
+							onClick={() => setIsOpen(false)}
+						>
+							タグ
+						</a>
 						{user ? (
 							<>
 								<a
@@ -37,6 +44,13 @@ export default function MobileNav({ user }: Props) {
 									onClick={() => setIsOpen(false)}
 								>
 									投稿
+								</a>
+								<a
+									href="/mypage"
+									className="text-muted-foreground hover:text-foreground transition-colors py-2"
+									onClick={() => setIsOpen(false)}
+								>
+									マイページ
 								</a>
 								<div className="flex items-center gap-2 py-2">
 									{user.avatarUrl ? (

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,0 +1,30 @@
+---
+interface TagItem {
+	id: string;
+	name: string;
+	slug: string;
+	category: string;
+	articleCount?: number;
+}
+
+interface Props {
+	tags: TagItem[];
+	baseUrl?: string;
+}
+
+const { tags, baseUrl = '/tags' } = Astro.props;
+---
+
+<div class="flex flex-wrap gap-2">
+	{tags.map((tag) => (
+		<a
+			href={`${baseUrl}/${tag.slug}`}
+			class="inline-block rounded-md bg-secondary px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+		>
+			{tag.name}
+			{tag.articleCount != null && (
+				<span class="ml-1 text-muted-foreground/70">({tag.articleCount})</span>
+			)}
+		</a>
+	))}
+</div>

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -50,6 +50,7 @@ interface ArticleDetail {
 	updatedAt: Date;
 	author: AuthorInfo;
 	tags: TagInfo[];
+	reactionCount: number;
 }
 
 async function getTagsForArticles(
@@ -131,6 +132,8 @@ export async function listArticles(db: Database, options: ListArticlesOptions = 
 
 	const totalResult = await db.select({ total: count() }).from(articles).where(where);
 
+	const reactionCount = sql<number>`count(${reactions.userId})`.as('reaction_count');
+
 	let rows: {
 		id: string;
 		title: string;
@@ -144,11 +147,10 @@ export async function listArticles(db: Database, options: ListArticlesOptions = 
 		authorUsername: string | null;
 		authorDisplayName: string | null;
 		authorAvatarUrl: string | null;
+		reactionCount: number;
 	}[];
 
 	if (sort === 'popular') {
-		const reactionCount = sql<number>`count(${reactions.userId})`.as('reaction_count');
-
 		rows = await db
 			.select({
 				...selectFields,
@@ -164,10 +166,15 @@ export async function listArticles(db: Database, options: ListArticlesOptions = 
 			.offset(offset);
 	} else {
 		rows = await db
-			.select(selectFields)
+			.select({
+				...selectFields,
+				reactionCount,
+			})
 			.from(articles)
 			.leftJoin(profiles, eq(articles.authorId, profiles.id))
+			.leftJoin(reactions, eq(articles.id, reactions.articleId))
 			.where(where)
+			.groupBy(articles.id, profiles.id)
 			.orderBy(desc(articles.createdAt))
 			.limit(limit)
 			.offset(offset);
@@ -193,12 +200,15 @@ export async function listArticles(db: Database, options: ListArticlesOptions = 
 			avatarUrl: row.authorAvatarUrl ?? null,
 		},
 		tags: tagsMap.get(row.id) ?? [],
+		reactionCount: Number(row.reactionCount) || 0,
 	}));
 
 	return { data, meta: { page, limit, total } };
 }
 
 export async function getArticleBySlug(db: Database, slug: string): Promise<ArticleDetail | null> {
+	const reactionCountExpr = sql<number>`count(distinct ${reactions.userId})`.as('reaction_count');
+
 	const rows = await db
 		.select({
 			id: articles.id,
@@ -213,10 +223,13 @@ export async function getArticleBySlug(db: Database, slug: string): Promise<Arti
 			authorUsername: profiles.username,
 			authorDisplayName: profiles.displayName,
 			authorAvatarUrl: profiles.avatarUrl,
+			reactionCount: reactionCountExpr,
 		})
 		.from(articles)
 		.leftJoin(profiles, eq(articles.authorId, profiles.id))
+		.leftJoin(reactions, eq(articles.id, reactions.articleId))
 		.where(eq(articles.slug, slug))
+		.groupBy(articles.id, profiles.id)
 		.limit(1);
 
 	if (rows.length === 0) return null;
@@ -240,6 +253,7 @@ export async function getArticleBySlug(db: Database, slug: string): Promise<Arti
 			avatarUrl: row.authorAvatarUrl ?? null,
 		},
 		tags: tagsMap.get(row.id) ?? [],
+		reactionCount: Number(row.reactionCount) || 0,
 	};
 }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,11 +2,23 @@
 import ArticleCard from '../components/ArticleCard.astro';
 import Layout from '../layouts/Layout.astro';
 import { listArticles } from '../lib/articles';
+import { groupTagsByCategory, listTags, TAG_CATEGORIES } from '../lib/tags';
 
-const { data: articles } = await listArticles(Astro.locals.db, {
-	limit: 10,
-	status: 'published',
-});
+const categoryLabels: Record<string, string> = {
+	duty: 'コンテンツ',
+	job: 'ジョブ',
+	crafting: 'クラフター',
+	gathering: 'ギャザラー',
+	general: 'その他',
+};
+
+const [{ data: popularArticles }, { data: newestArticles }, allTags] = await Promise.all([
+	listArticles(Astro.locals.db, { limit: 6, sort: 'popular', status: 'published' }),
+	listArticles(Astro.locals.db, { limit: 6, sort: 'newest', status: 'published' }),
+	listTags(Astro.locals.db),
+]);
+
+const groupedTags = groupTagsByCategory(allTags);
 ---
 
 <Layout title="トップ" description="XIVPedia - ユーザー投稿型のFF14攻略サイト">
@@ -20,12 +32,12 @@ const { data: articles } = await listArticles(Astro.locals.db, {
 		</p>
 	</section>
 
-	<section class="pb-16">
-		<h2 class="text-2xl font-bold text-foreground mb-6">最新の記事</h2>
+	<section class="pb-12">
+		<h2 class="text-2xl font-bold text-foreground mb-6">🔥 人気の記事</h2>
 
-		{articles.length > 0 ? (
+		{popularArticles.length > 0 ? (
 			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				{articles.map((article) => (
+				{popularArticles.map((article) => (
 					<ArticleCard
 						title={article.title}
 						slug={article.slug}
@@ -33,6 +45,7 @@ const { data: articles } = await listArticles(Astro.locals.db, {
 						tags={article.tags}
 						publishedAt={article.publishedAt}
 						createdAt={article.createdAt}
+						reactionCount={article.reactionCount}
 					/>
 				))}
 			</div>
@@ -41,5 +54,57 @@ const { data: articles } = await listArticles(Astro.locals.db, {
 				<p class="text-muted-foreground">まだ記事がありません。</p>
 			</div>
 		)}
+	</section>
+
+	<section class="pb-12">
+		<h2 class="text-2xl font-bold text-foreground mb-6">🆕 新着記事</h2>
+
+		{newestArticles.length > 0 ? (
+			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{newestArticles.map((article) => (
+					<ArticleCard
+						title={article.title}
+						slug={article.slug}
+						author={article.author}
+						tags={article.tags}
+						publishedAt={article.publishedAt}
+						createdAt={article.createdAt}
+						reactionCount={article.reactionCount}
+					/>
+				))}
+			</div>
+		) : (
+			<div class="rounded-lg border border-border bg-card p-12 text-center">
+				<p class="text-muted-foreground">まだ記事がありません。</p>
+			</div>
+		)}
+	</section>
+
+	<section class="pb-16">
+		<h2 class="text-2xl font-bold text-foreground mb-6">🏷️ カテゴリ</h2>
+
+		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+			{TAG_CATEGORIES.map((category) => {
+				const tagsInCategory = groupedTags[category] ?? [];
+				if (tagsInCategory.length === 0) return null;
+				return (
+					<div class="bg-card rounded-lg border border-border p-6">
+						<h3 class="text-lg font-bold text-foreground mb-4">
+							{categoryLabels[category] ?? category}
+						</h3>
+						<div class="flex flex-wrap gap-2">
+							{tagsInCategory.map((tag) => (
+								<a
+									href={`/tags/${tag.slug}`}
+									class="inline-block rounded-md bg-secondary px-3 py-1 text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/80 transition-colors"
+								>
+									{tag.name}
+								</a>
+							))}
+						</div>
+					</div>
+				);
+			})}
+		</div>
 	</section>
 </Layout>

--- a/src/pages/mypage.astro
+++ b/src/pages/mypage.astro
@@ -1,0 +1,165 @@
+---
+import { desc, eq, inArray, sql } from 'drizzle-orm';
+import { articles, articleTags, reactions, tags } from '../db/schema';
+import Layout from '../layouts/Layout.astro';
+
+const currentUser = Astro.locals.currentUser;
+if (!currentUser) {
+	return Astro.redirect('/login');
+}
+if (!currentUser.profile) {
+	return Astro.redirect('/onboarding');
+}
+
+const db = Astro.locals.db;
+const userId = currentUser.profile.id;
+
+const myArticles = await db
+	.select({
+		id: articles.id,
+		title: articles.title,
+		slug: articles.slug,
+		status: articles.status,
+		publishedAt: articles.publishedAt,
+		createdAt: articles.createdAt,
+		updatedAt: articles.updatedAt,
+		reactionCount: sql<number>`count(distinct ${reactions.userId})`,
+	})
+	.from(articles)
+	.leftJoin(reactions, eq(articles.id, reactions.articleId))
+	.where(eq(articles.authorId, userId))
+	.groupBy(articles.id)
+	.orderBy(desc(articles.updatedAt));
+
+const articleIds = myArticles.map((a) => a.id);
+const articleTagRows =
+	articleIds.length > 0
+		? await db
+				.select({
+					articleId: articleTags.articleId,
+					tagName: tags.name,
+					tagSlug: tags.slug,
+				})
+				.from(articleTags)
+				.innerJoin(tags, eq(articleTags.tagId, tags.id))
+				.where(inArray(articleTags.articleId, articleIds))
+		: [];
+
+const tagsByArticle = new Map<string, { name: string; slug: string }[]>();
+for (const row of articleTagRows) {
+	const list = tagsByArticle.get(row.articleId) ?? [];
+	list.push({ name: row.tagName, slug: row.tagSlug });
+	tagsByArticle.set(row.articleId, list);
+}
+
+const publishedCount = myArticles.filter((a) => a.status === 'published').length;
+const draftCount = myArticles.filter((a) => a.status === 'draft').length;
+
+function formatDate(date: Date | null): string {
+	if (!date) return '';
+	return date.toLocaleDateString('ja-JP', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	});
+}
+---
+
+<Layout title="マイページ">
+	<section class="py-8">
+		<h1 class="text-3xl font-bold text-foreground">マイページ</h1>
+
+		<p class="mt-4 text-lg text-muted-foreground">
+			{currentUser.profile.displayName} さんの記事
+		</p>
+
+		<div class="mt-4 flex items-center gap-4 text-sm text-muted-foreground">
+			<span>公開: {publishedCount}件</span>
+			<span>/</span>
+			<span>下書き: {draftCount}件</span>
+		</div>
+
+		{myArticles.length > 0 ? (
+			<div class="mt-8 space-y-4">
+				{myArticles.map((article) => {
+					const isPublished = article.status === 'published';
+					const articleTagList = tagsByArticle.get(article.id) ?? [];
+					const titleHref = isPublished
+						? `/articles/${article.slug}`
+						: `/articles/${article.slug}/edit`;
+
+					return (
+						<div class="bg-card rounded-lg border border-border p-4 hover:border-primary/50 transition-colors">
+							<a href={titleHref} class="text-lg font-bold text-foreground hover:text-primary transition-colors">
+								{article.title}
+							</a>
+
+							<div class="mt-2 flex flex-wrap items-center gap-3 text-sm">
+								{isPublished ? (
+									<span class="bg-green-500/20 text-green-400 rounded-full px-2 py-0.5 text-xs">
+										公開中
+									</span>
+								) : (
+									<span class="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs">
+										下書き
+									</span>
+								)}
+
+								<span class="text-muted-foreground">
+									{formatDate(article.updatedAt)}
+								</span>
+
+								{isPublished && article.reactionCount > 0 && (
+									<span class="text-muted-foreground">
+										👍 {article.reactionCount}
+									</span>
+								)}
+							</div>
+
+							<div class="mt-3 flex items-center justify-between">
+								<div class="flex flex-wrap gap-2">
+									{articleTagList.map((tag) => (
+										<a
+											href={`/tags/${tag.slug}`}
+											class="inline-block rounded-md bg-secondary px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+										>
+											{tag.name}
+										</a>
+									))}
+								</div>
+
+								<a
+									href={`/articles/${article.slug}/edit`}
+									class="text-sm text-primary hover:opacity-80 transition-opacity"
+								>
+									編集
+								</a>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		) : (
+			<div class="mt-8 rounded-lg border border-border bg-card p-12 text-center">
+				<p class="text-muted-foreground">
+					まだ記事がありません。最初の記事を書いてみましょう！
+				</p>
+				<a
+					href="/articles/new"
+					class="mt-4 inline-block bg-primary text-primary-foreground px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 transition-opacity"
+				>
+					記事を書く
+				</a>
+			</div>
+		)}
+
+		<div class="mt-8">
+			<a
+				href="/articles/new"
+				class="inline-block bg-primary text-primary-foreground px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 transition-opacity"
+			>
+				新しい記事を書く →
+			</a>
+		</div>
+	</section>
+</Layout>

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -1,0 +1,94 @@
+---
+import ArticleCard from '../../components/ArticleCard.astro';
+import Pagination from '../../components/Pagination.astro';
+import Layout from '../../layouts/Layout.astro';
+import { listArticles } from '../../lib/articles';
+import { listTags } from '../../lib/tags';
+
+const { slug } = Astro.params;
+if (!slug) return Astro.redirect('/tags');
+
+const allTags = await listTags(Astro.locals.db);
+const currentTag = allTags.find((t) => t.slug === slug);
+if (!currentTag) return Astro.redirect('/tags');
+
+const page = Math.max(1, Number(Astro.url.searchParams.get('page')) || 1);
+const sort = Astro.url.searchParams.get('sort') === 'popular' ? 'popular' : 'newest';
+
+const { data: articles, meta } = await listArticles(Astro.locals.db, {
+	page,
+	limit: 12,
+	sort,
+	tag: slug,
+	status: 'published',
+});
+
+const totalPages = Math.ceil(meta.total / meta.limit);
+const baseUrl = `/tags/${slug}?sort=${sort}`;
+const pageTitle = `タグ: ${currentTag.name}の記事`;
+
+function sortUrl(sortValue: 'newest' | 'popular'): string {
+	return `/tags/${slug}?sort=${sortValue}`;
+}
+---
+
+<Layout title={pageTitle} description={`XIVPedia - ${pageTitle}`}>
+	<section class="py-8">
+		<h1 class="text-3xl font-bold text-foreground">{pageTitle}</h1>
+
+		<div class="mt-6 flex items-center gap-2">
+			<a
+				href={sortUrl('newest')}
+				class:list={[
+					'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
+					sort === 'newest'
+						? 'bg-primary text-primary-foreground border-primary'
+						: 'bg-card text-muted-foreground border-border hover:text-foreground',
+				]}
+			>
+				新着順
+			</a>
+			<a
+				href={sortUrl('popular')}
+				class:list={[
+					'inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
+					sort === 'popular'
+						? 'bg-primary text-primary-foreground border-primary'
+						: 'bg-card text-muted-foreground border-border hover:text-foreground',
+				]}
+			>
+				人気順
+			</a>
+		</div>
+
+		{articles.length > 0 ? (
+			<div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{articles.map((article) => (
+					<ArticleCard
+						title={article.title}
+						slug={article.slug}
+						author={article.author}
+						tags={article.tags}
+						publishedAt={article.publishedAt}
+						createdAt={article.createdAt}
+						reactionCount={article.reactionCount}
+					/>
+				))}
+			</div>
+		) : (
+			<div class="mt-8 rounded-lg border border-border bg-card p-12 text-center">
+				<p class="text-muted-foreground">このタグの記事はまだありません</p>
+			</div>
+		)}
+
+		{totalPages > 1 && (
+			<div class="mt-8">
+				<Pagination
+					currentPage={page}
+					totalPages={totalPages}
+					baseUrl={baseUrl}
+				/>
+			</div>
+		)}
+	</section>
+</Layout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,57 @@
+---
+import { count, eq } from 'drizzle-orm';
+import TagList from '../../components/TagList.astro';
+import { articles, articleTags } from '../../db/schema';
+import Layout from '../../layouts/Layout.astro';
+import { groupTagsByCategory, listTags, TAG_CATEGORIES } from '../../lib/tags';
+
+const allTags = await listTags(Astro.locals.db);
+const grouped = groupTagsByCategory(allTags);
+
+const tagCounts = await Astro.locals.db
+	.select({
+		tagId: articleTags.tagId,
+		count: count(),
+	})
+	.from(articleTags)
+	.innerJoin(articles, eq(articleTags.articleId, articles.id))
+	.where(eq(articles.status, 'published'))
+	.groupBy(articleTags.tagId);
+
+const countMap = new Map(tagCounts.map((r) => [r.tagId, r.count]));
+
+const categoryNames: Record<string, string> = {
+	duty: 'コンテンツ',
+	job: 'ジョブ',
+	crafting: 'クラフター',
+	gathering: 'ギャザラー',
+	general: 'その他',
+};
+---
+
+<Layout title="タグ一覧" description="XIVPedia - タグ一覧">
+	<section class="py-8">
+		<h1 class="text-3xl font-bold text-foreground">タグ一覧</h1>
+
+		<div class="mt-8 space-y-10">
+			{TAG_CATEGORIES.map((category) => {
+				const tagsInCategory = grouped[category];
+				if (!tagsInCategory || tagsInCategory.length === 0) return null;
+
+				const tagsWithCount = tagsInCategory.map(t => ({
+					...t,
+					articleCount: countMap.get(t.id) ?? 0,
+				}));
+
+				return (
+					<section>
+						<h2 class="text-2xl font-bold text-foreground mb-6">
+							{categoryNames[category]}
+						</h2>
+						<TagList tags={tagsWithCount} />
+					</section>
+				);
+			})}
+		</div>
+	</section>
+</Layout>


### PR DESCRIPTION
## Summary

Closes #13

- トップページを人気記事・新着記事・カテゴリセクションの3構成に拡張
- タグ一覧ページ (`/tags`) とタグ別記事一覧ページ (`/tags/[slug]`) を新規作成
- 認証必須のマイページ (`/mypage`) を新規作成（公開・下書き記事の管理）
- ArticleCard にリアクション数表示を追加
- ヘッダー・モバイルナビにタグ・マイページへのリンクを追加

## 変更ファイル

### 新規作成
- `src/pages/tags/index.astro` — カテゴリ別タグ一覧（記事数表示付き）
- `src/pages/tags/[slug].astro` — タグ別記事一覧（ソート・ページネーション付き）
- `src/components/TagList.astro` — 再利用可能なタグ一覧コンポーネント
- `src/pages/mypage.astro` — マイページ（認証必須、自分の記事管理）

### 変更
- `src/pages/index.astro` — 人気記事・新着記事・カテゴリの3セクション構成に拡張
- `src/lib/articles.ts` — `ArticleDetail` に `reactionCount` を追加、`getArticleBySlug` でもリアクション数を集計
- `src/components/ArticleCard.astro` — `reactionCount` 表示を追加
- `src/components/Header.astro` — タグ・マイページへのナビリンク追加
- `src/components/MobileNav.tsx` — モバイルナビにタグ・マイページリンク追加

## Test plan

- [ ] トップページに人気記事・新着記事・カテゴリが表示される
- [ ] `/tags` でカテゴリ別タグ一覧が表示される
- [ ] `/tags/[slug]` でタグ別記事一覧が表示される（ソート・ページネーション付き）
- [ ] `/mypage` で自分の記事一覧が表示される（認証必須）
- [ ] マイページから各記事の編集ページに遷移できる
- [ ] 下書き記事はマイページでのみ表示される
- [ ] ページネーションが正しく動作する
- [ ] レスポンシブデザイン
- [ ] `pnpm astro check` / `pnpm biome check .` がエラーなく通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)