### PR TITLE
feat: 全文検索（Postgres）APIと検索UIを実装 (#12)

### DIFF
--- a/drizzle/0001_search_index.sql
+++ b/drizzle/0001_search_index.sql
@@ -1,0 +1,6 @@
+-- pg_trgm 拡張の有効化
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 検索用 GIN インデックス
+CREATE INDEX idx_articles_title_trgm ON articles USING gin (title gin_trgm_ops);
+CREATE INDEX idx_articles_body_trgm ON articles USING gin (body gin_trgm_ops);

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import MobileNav from './MobileNav.tsx';
+import SearchBar from './SearchBar.astro';
 import UserMenu from './UserMenu.tsx';
 
 const currentUser = Astro.locals.currentUser;
@@ -14,7 +15,7 @@ const currentUser = Astro.locals.currentUser;
 			</a>
 
 			<!-- Desktop Navigation -->
-			<nav class="hidden md:flex items-center gap-6">
+			<nav class="hidden md:flex items-center gap-4">
 				<a
 					href="/articles"
 					class="text-muted-foreground hover:text-foreground transition-colors"
@@ -27,6 +28,9 @@ const currentUser = Astro.locals.currentUser;
 				>
 					タグ
 				</a>
+				<div class="w-48">
+					<SearchBar />
+				</div>
 				{
 					currentUser ? (
 						<>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Menu, Settings, User, X } from 'lucide-react';
+import { LogOut, Menu, Search, Settings, User, X } from 'lucide-react';
 import { useState } from 'react';
 
 interface Props {
@@ -35,6 +35,14 @@ export default function MobileNav({ user }: Props) {
 							onClick={() => setIsOpen(false)}
 						>
 							タグ
+						</a>
+						<a
+							href="/search"
+							className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors py-2"
+							onClick={() => setIsOpen(false)}
+						>
+							<Search size={16} />
+							検索
 						</a>
 						{user ? (
 							<>

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -1,0 +1,32 @@
+---
+const q = Astro.url.searchParams.get('q') ?? '';
+---
+
+<form action="/search" method="GET" class="relative">
+	<label for="search-input" class="sr-only">記事を検索</label>
+	<!-- Search アイコン（lucide の Search を SVG で直接記述） -->
+	<svg
+		class="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+		xmlns="http://www.w3.org/2000/svg"
+		width="16"
+		height="16"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	>
+		<circle cx="11" cy="11" r="8" />
+		<path d="m21 21-4.3-4.3" />
+	</svg>
+	<input
+		id="search-input"
+		type="text"
+		name="q"
+		value={q}
+		placeholder="記事を検索..."
+		class="h-9 w-full rounded-md bg-secondary pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground
+			focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background transition-colors"
+	/>
+</form>

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,166 @@
+import { and, count, eq, inArray, sql } from 'drizzle-orm';
+import type { Database } from '../db';
+import { articles, articleTags, profiles, reactions, tags } from '../db/schema';
+
+export interface SearchArticlesOptions {
+	query: string;
+	page?: number;
+	limit?: number;
+}
+
+export interface SearchResult {
+	slug: string;
+	title: string;
+	excerpt: string;
+	author: { displayName: string; avatarUrl: string | null };
+	publishedAt: string | null;
+	reactionCount: number;
+	tags: { name: string; slug: string }[];
+}
+
+export interface SearchResponse {
+	results: SearchResult[];
+	total: number;
+	page: number;
+	limit: number;
+}
+
+/**
+ * 記事本文から検索キーワード周辺の抜粋を生成する。
+ * キーワードが見つかった場合はその周辺を中心に最大200文字を切り出す。
+ * 見つからない場合は先頭200文字を返す。
+ */
+function generateExcerpt(body: string, query: string, maxLength = 200): string {
+	const lowerBody = body.toLowerCase();
+	const lowerQuery = query.toLowerCase();
+	const index = lowerBody.indexOf(lowerQuery);
+
+	if (index === -1) {
+		// キーワードが見つからない場合は先頭から切り出し
+		if (body.length <= maxLength) return body;
+		return `${body.slice(0, maxLength)}...`;
+	}
+
+	// キーワードを中心に前後を切り出す
+	const halfWindow = Math.floor((maxLength - query.length) / 2);
+	const start = Math.max(0, index - halfWindow);
+	let end = Math.min(body.length, index + query.length + halfWindow);
+
+	// 切り出し範囲が maxLength を超えないように調整
+	if (end - start > maxLength) {
+		end = start + maxLength;
+	}
+
+	let excerpt = body.slice(start, end);
+	if (start > 0) excerpt = `...${excerpt}`;
+	if (end < body.length) excerpt = `${excerpt}...`;
+
+	return excerpt;
+}
+
+/**
+ * 全文検索で記事を検索する。
+ * pg_trgm の ILIKE を使用して title と body を検索し、
+ * published 状態の記事のみを対象とする。
+ */
+export async function searchArticles(
+	db: Database,
+	options: SearchArticlesOptions,
+): Promise<SearchResponse> {
+	const { query } = options;
+	const page = Math.max(1, options.page || 1);
+	const limit = Math.min(100, Math.max(1, options.limit || 20));
+	const offset = (page - 1) * limit;
+
+	// 空クエリの場合は空結果を返す
+	if (!query || query.trim() === '') {
+		return { results: [], total: 0, page, limit };
+	}
+
+	const escapedQuery = query.replace(/[%_\\]/g, '\\$&');
+	const searchPattern = `%${escapedQuery}%`;
+
+	// 検索条件: published かつ title または body に ILIKE マッチ
+	const where = and(
+		eq(articles.status, 'published'),
+		sql`(${articles.title} ILIKE ${searchPattern} OR ${articles.body} ILIKE ${searchPattern})`,
+	);
+
+	// 合計件数を取得
+	const totalResult = await db.select({ total: count() }).from(articles).where(where);
+	const total = totalResult[0]?.total ?? 0;
+
+	if (total === 0) {
+		return { results: [], total: 0, page, limit };
+	}
+
+	// 記事データを取得（リアクション数を含む）
+	const reactionCount = sql<number>`count(DISTINCT ${reactions.userId})`.as('reaction_count');
+
+	const rows = await db
+		.select({
+			id: articles.id,
+			slug: articles.slug,
+			title: articles.title,
+			body: articles.body,
+			publishedAt: articles.publishedAt,
+			authorDisplayName: profiles.displayName,
+			authorAvatarUrl: profiles.avatarUrl,
+			reactionCount,
+		})
+		.from(articles)
+		.leftJoin(profiles, eq(articles.authorId, profiles.id))
+		.leftJoin(reactions, eq(articles.id, reactions.articleId))
+		.where(where)
+		.groupBy(articles.id, profiles.id)
+		.orderBy(sql`${articles.publishedAt} DESC NULLS LAST`)
+		.limit(limit)
+		.offset(offset);
+
+	// 記事IDリストからタグ情報を一括取得
+	const articleIds = rows.map((r) => r.id);
+	const tagsMap = await getTagsForArticles(db, articleIds);
+
+	const results: SearchResult[] = rows.map((row) => ({
+		slug: row.slug,
+		title: row.title,
+		excerpt: generateExcerpt(row.body, query),
+		author: {
+			displayName: row.authorDisplayName ?? '不明',
+			avatarUrl: row.authorAvatarUrl ?? null,
+		},
+		publishedAt: row.publishedAt?.toISOString() ?? null,
+		reactionCount: Number(row.reactionCount),
+		tags: tagsMap.get(row.id) ?? [],
+	}));
+
+	return { results, total, page, limit };
+}
+
+/**
+ * 記事IDリストに対応するタグ情報を取得する
+ */
+async function getTagsForArticles(
+	db: Database,
+	articleIds: string[],
+): Promise<Map<string, { name: string; slug: string }[]>> {
+	if (articleIds.length === 0) return new Map();
+
+	const rows = await db
+		.select({
+			articleId: articleTags.articleId,
+			name: tags.name,
+			slug: tags.slug,
+		})
+		.from(articleTags)
+		.innerJoin(tags, eq(articleTags.tagId, tags.id))
+		.where(inArray(articleTags.articleId, articleIds));
+
+	const map = new Map<string, { name: string; slug: string }[]>();
+	for (const row of rows) {
+		const list = map.get(row.articleId) ?? [];
+		list.push({ name: row.name, slug: row.slug });
+		map.set(row.articleId, list);
+	}
+	return map;
+}

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -1,0 +1,18 @@
+import type { APIContext } from 'astro';
+import { searchArticles } from '../../lib/search';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db } = context.locals;
+	const params = context.url.searchParams;
+
+	const query = params.get('q') ?? '';
+	const page = Number.parseInt(params.get('page') ?? '1', 10) || 1;
+	const limit = Number.parseInt(params.get('limit') ?? '20', 10) || 20;
+
+	const result = await searchArticles(db, { query, page, limit });
+
+	return new Response(JSON.stringify(result), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,185 @@
+---
+import Pagination from '../components/Pagination.astro';
+import SearchBar from '../components/SearchBar.astro';
+import Layout from '../layouts/Layout.astro';
+import type { SearchResponse } from '../lib/search';
+import { searchArticles } from '../lib/search';
+
+const q = Astro.url.searchParams.get('q')?.trim() ?? '';
+const page = Math.max(1, Number(Astro.url.searchParams.get('page')) || 1);
+const limit = 20;
+
+let searchData: SearchResponse | null = null;
+let searchError = false;
+
+if (q) {
+	try {
+		searchData = await searchArticles(Astro.locals.db, { query: q, page, limit });
+	} catch {
+		searchError = true;
+	}
+}
+
+const total = searchData?.total ?? 0;
+const totalPages = searchData ? Math.ceil(searchData.total / searchData.limit) : 0;
+const results = searchData?.results ?? [];
+const baseUrl = `/search?q=${encodeURIComponent(q)}`;
+
+function formatDate(dateStr: string | null): string {
+	if (!dateStr) return '';
+	return new Date(dateStr).toLocaleDateString('ja-JP');
+}
+---
+
+<Layout title={q ? `「${q}」の検索結果` : '検索'} description={q ? `「${q}」の検索結果 - XIVPedia` : '記事を検索 - XIVPedia'}>
+	<section class="py-8">
+		{/* 検索フォーム */}
+		<div class="max-w-xl mx-auto">
+			<h1 class="text-3xl font-bold text-foreground mb-6">検索</h1>
+			<SearchBar />
+		</div>
+
+		{/* 検索結果 */}
+		{q ? (
+			<div class="mt-8">
+				{searchError ? (
+					<div class="rounded-lg border border-border bg-card p-12 text-center">
+						<p class="text-muted-foreground">検索中にエラーが発生しました。もう一度お試しください。</p>
+					</div>
+				) : results.length > 0 ? (
+					<>
+						<p class="text-muted-foreground mb-6">
+							「<span class="text-foreground font-medium">{q}</span>」の検索結果（{total}件）
+						</p>
+						<div class="flex flex-col gap-4">
+							{results.map((result) => (
+								<article class="bg-card rounded-lg border border-border p-6 hover:border-primary/50 transition-colors">
+									<a href={`/articles/${result.slug}`} class="block group">
+										<h2 class="text-lg font-bold text-foreground group-hover:text-primary transition-colors line-clamp-2">
+											{result.title}
+										</h2>
+									</a>
+
+									{/* 抜粋テキスト */}
+									{result.excerpt && (
+										<p class="mt-2 text-sm text-muted-foreground line-clamp-3">
+											{result.excerpt}
+										</p>
+									)}
+
+									{/* 著者・日付・リアクション */}
+									<div class="mt-3 flex items-center gap-3 text-sm text-muted-foreground">
+										<div class="flex items-center gap-1.5">
+											{result.author.avatarUrl ? (
+												<img
+													src={result.author.avatarUrl}
+													alt={result.author.displayName}
+													class="w-5 h-5 rounded-full"
+													loading="lazy"
+												/>
+											) : (
+												<span class="w-5 h-5 rounded-full bg-secondary flex items-center justify-center text-xs">
+													{result.author.displayName.charAt(0)}
+												</span>
+											)}
+											<span>{result.author.displayName}</span>
+										</div>
+										{result.publishedAt && (
+											<time datetime={result.publishedAt}>
+												{formatDate(result.publishedAt)}
+											</time>
+										)}
+										{result.reactionCount > 0 && (
+											<div class="flex items-center gap-1">
+												{/* ハートアイコン（lucide の Heart を SVG で直接記述） */}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													width="14"
+													height="14"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="2"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													class="text-muted-foreground"
+												>
+													<path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+												</svg>
+												<span>{result.reactionCount}</span>
+											</div>
+										)}
+									</div>
+
+									{/* タグ */}
+									{result.tags.length > 0 && (
+										<div class="mt-3 flex flex-wrap gap-2">
+											{result.tags.map((tag) => (
+												<a
+													href={`/articles?tag=${encodeURIComponent(tag.slug)}`}
+													class="inline-block rounded-md bg-secondary px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+												>
+													{tag.name}
+												</a>
+											))}
+										</div>
+									)}
+								</article>
+							))}
+						</div>
+
+						{/* ページネーション */}
+						{totalPages > 1 && (
+							<div class="mt-8">
+								<Pagination
+									currentPage={page}
+									totalPages={totalPages}
+									baseUrl={baseUrl}
+								/>
+							</div>
+						)}
+					</>
+				) : (
+					<div class="rounded-lg border border-border bg-card p-12 text-center">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="48"
+							height="48"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							class="mx-auto text-muted-foreground mb-4"
+						>
+							<circle cx="11" cy="11" r="8" />
+							<path d="m21 21-4.3-4.3" />
+						</svg>
+						<p class="text-muted-foreground">検索結果が見つかりませんでした</p>
+						<p class="text-sm text-muted-foreground mt-2">別のキーワードで検索してみてください</p>
+					</div>
+				)}
+			</div>
+		) : (
+			<div class="mt-8 rounded-lg border border-border bg-card p-12 text-center">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="48"
+					height="48"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					class="mx-auto text-muted-foreground mb-4"
+				>
+					<circle cx="11" cy="11" r="8" />
+					<path d="m21 21-4.3-4.3" />
+				</svg>
+				<p class="text-muted-foreground">キーワードを入力して記事を検索してください</p>
+			</div>
+		)}
+	</section>
+</Layout>


### PR DESCRIPTION
## Summary
Closes #12

- PostgreSQL の `pg_trgm` 拡張を利用した全文検索 API（`GET /api/search`）を実装
- ヘッダーに検索バーを追加し、検索結果ページ（`/search`）を新規作成
- ILIKE + GIN インデックスによるタイトル・本文の部分一致検索、ページネーション対応

### 新規ファイル
- `drizzle/0001_search_index.sql` — pg_trgm 拡張 + GIN インデックス
- `src/lib/search.ts` — 検索ライブラリ（ILIKE 検索、抜粋生成、リアクション数取得）
- `src/pages/api/search.ts` — 検索 API エンドポイント
- `src/components/SearchBar.astro` — 検索バーコンポーネント
- `src/pages/search.astro` — 検索結果ページ

### 変更ファイル
- `src/components/Header.astro` — デスクトップナビに検索バー追加
- `src/components/MobileNav.tsx` — モバイルメニューに検索リンク追加

## Test plan
- [ ] `pnpm astro check` がエラーなし
- [ ] `pnpm biome check .` がエラーなし
- [ ] `GET /api/search?q=キーワード` で記事を検索できる
- [ ] タイトルと本文の両方が検索対象になる
- [ ] 検索結果にタイトル・抜粋・著者・公開日・リアクション数・タグが含まれる
- [ ] ヘッダーに検索バーが表示される
- [ ] `/search?q=キーワード` で検索結果ページが表示される
- [ ] 0件時に適切なメッセージが表示される
- [ ] ページネーションが機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)