### PR TITLE
feat: モデレーション機能（通報・削除・レート制限）を実装 (#14)

### DIFF
--- a/drizzle/0000_perpetual_moondragon.sql
+++ b/drizzle/0000_perpetual_moondragon.sql
@@ -1,0 +1,77 @@
+CREATE TABLE "article_tags" (
+	"article_id" uuid NOT NULL,
+	"tag_id" uuid NOT NULL,
+	CONSTRAINT "article_tags_article_id_tag_id_pk" PRIMARY KEY("article_id","tag_id")
+);
+--> statement-breakpoint
+CREATE TABLE "articles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"title" text NOT NULL,
+	"slug" text NOT NULL,
+	"body" text NOT NULL,
+	"author_id" uuid NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"published_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "articles_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "comments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"body" text NOT NULL,
+	"article_id" uuid NOT NULL,
+	"author_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "profiles" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"display_name" text NOT NULL,
+	"avatar_url" text,
+	"role" text DEFAULT 'user' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "profiles_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+CREATE TABLE "reactions" (
+	"article_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "reactions_article_id_user_id_pk" PRIMARY KEY("article_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"reason" text NOT NULL,
+	"description" text,
+	"target_type" text NOT NULL,
+	"target_id" uuid NOT NULL,
+	"reporter_id" uuid NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"resolved_by" uuid,
+	"resolved_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"category" text NOT NULL,
+	CONSTRAINT "tags_name_unique" UNIQUE("name"),
+	CONSTRAINT "tags_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "article_tags" ADD CONSTRAINT "article_tags_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "article_tags" ADD CONSTRAINT "article_tags_tag_id_tags_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "articles" ADD CONSTRAINT "articles_author_id_profiles_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_author_id_profiles_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reactions" ADD CONSTRAINT "reactions_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reactions" ADD CONSTRAINT "reactions_user_id_profiles_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reports" ADD CONSTRAINT "reports_reporter_id_profiles_id_fk" FOREIGN KEY ("reporter_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reports" ADD CONSTRAINT "reports_resolved_by_profiles_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,490 @@
+{
+	"id": "d6992aad-538f-4fb1-8a53-dceb8cb20209",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.article_tags": {
+			"name": "article_tags",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"article_tags_article_id_articles_id_fk": {
+					"name": "article_tags_article_id_articles_id_fk",
+					"tableFrom": "article_tags",
+					"tableTo": "articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"article_tags_tag_id_tags_id_fk": {
+					"name": "article_tags_tag_id_tags_id_fk",
+					"tableFrom": "article_tags",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"article_tags_article_id_tag_id_pk": {
+					"name": "article_tags_article_id_tag_id_pk",
+					"columns": ["article_id", "tag_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.articles": {
+			"name": "articles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"articles_author_id_profiles_id_fk": {
+					"name": "articles_author_id_profiles_id_fk",
+					"tableFrom": "articles",
+					"tableTo": "profiles",
+					"columnsFrom": ["author_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"articles_slug_unique": {
+					"name": "articles_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.comments": {
+			"name": "comments",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"comments_article_id_articles_id_fk": {
+					"name": "comments_article_id_articles_id_fk",
+					"tableFrom": "comments",
+					"tableTo": "articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"comments_author_id_profiles_id_fk": {
+					"name": "comments_author_id_profiles_id_fk",
+					"tableFrom": "comments",
+					"tableTo": "profiles",
+					"columnsFrom": ["author_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.profiles": {
+			"name": "profiles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avatar_url": {
+					"name": "avatar_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"profiles_username_unique": {
+					"name": "profiles_username_unique",
+					"nullsNotDistinct": false,
+					"columns": ["username"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.reactions": {
+			"name": "reactions",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"reactions_article_id_articles_id_fk": {
+					"name": "reactions_article_id_articles_id_fk",
+					"tableFrom": "reactions",
+					"tableTo": "articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"reactions_user_id_profiles_id_fk": {
+					"name": "reactions_user_id_profiles_id_fk",
+					"tableFrom": "reactions",
+					"tableTo": "profiles",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"reactions_article_id_user_id_pk": {
+					"name": "reactions_article_id_user_id_pk",
+					"columns": ["article_id", "user_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.reports": {
+			"name": "reports",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_type": {
+					"name": "target_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reporter_id": {
+					"name": "reporter_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"resolved_by": {
+					"name": "resolved_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"reports_reporter_id_profiles_id_fk": {
+					"name": "reports_reporter_id_profiles_id_fk",
+					"tableFrom": "reports",
+					"tableTo": "profiles",
+					"columnsFrom": ["reporter_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"reports_resolved_by_profiles_id_fk": {
+					"name": "reports_resolved_by_profiles_id_fk",
+					"tableFrom": "reports",
+					"tableTo": "profiles",
+					"columnsFrom": ["resolved_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tags": {
+			"name": "tags",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"tags_name_unique": {
+					"name": "tags_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				},
+				"tags_slug_unique": {
+					"name": "tags_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1772589200718,
+			"tag": "0000_perpetual_moondragon",
+			"breakpoints": true
+		}
+	]
+}

--- a/src/components/ArticleContent.astro
+++ b/src/components/ArticleContent.astro
@@ -1,12 +1,28 @@
 ---
+import ReportButton from './ReportButton.tsx';
+
 interface Props {
 	html: string;
+	articleId?: string;
+	isLoggedIn?: boolean;
 }
 
-const { html } = Astro.props;
+const { html, articleId, isLoggedIn = false } = Astro.props;
 ---
 
-<div class="article-content" set:html={html} />
+<div class="article-content-wrapper">
+	{articleId && (
+		<div class="mb-4 flex justify-end">
+			<ReportButton
+				client:load
+				targetType="article"
+				targetId={articleId}
+				isLoggedIn={isLoggedIn}
+			/>
+		</div>
+	)}
+	<div class="article-content" set:html={html} />
+</div>
 
 <style>
 	.article-content {

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -1,0 +1,215 @@
+import { Flag, Loader2, X } from 'lucide-react';
+import { useState } from 'react';
+
+interface ReportButtonProps {
+	targetType: 'article' | 'comment';
+	targetId: string;
+	isLoggedIn: boolean;
+}
+
+type ReportReason = 'spam' | 'inappropriate' | 'misleading' | 'other';
+
+const REASON_LABELS: Record<ReportReason, string> = {
+	spam: 'スパム',
+	inappropriate: '不適切',
+	misleading: '誤情報',
+	other: 'その他',
+};
+
+export default function ReportButton({ targetType, targetId, isLoggedIn }: ReportButtonProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [reason, setReason] = useState<ReportReason | ''>('');
+	const [description, setDescription] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [successMessage, setSuccessMessage] = useState<string | null>(null);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	if (!isLoggedIn) {
+		return null;
+	}
+
+	function handleOpen() {
+		setIsOpen(true);
+		setReason('');
+		setDescription('');
+		setSuccessMessage(null);
+		setErrorMessage(null);
+	}
+
+	function handleClose() {
+		setIsOpen(false);
+		setReason('');
+		setDescription('');
+		setSuccessMessage(null);
+		setErrorMessage(null);
+	}
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+
+		if (!reason) {
+			setErrorMessage('通報理由を選択してください');
+			return;
+		}
+
+		setIsSubmitting(true);
+		setErrorMessage(null);
+
+		try {
+			const res = await fetch('/api/reports', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					reason,
+					description: description.trim() || undefined,
+					targetType,
+					targetId,
+				}),
+			});
+
+			if (!res.ok) {
+				const json = await res.json().catch(() => null);
+				if (res.status === 409) {
+					setErrorMessage('すでに通報済みです');
+				} else {
+					setErrorMessage(json?.error ?? '通報の送信に失敗しました');
+				}
+				return;
+			}
+
+			setSuccessMessage('通報を受け付けました');
+			setTimeout(() => {
+				handleClose();
+			}, 1500);
+		} catch {
+			setErrorMessage('通報の送信に失敗しました');
+		} finally {
+			setIsSubmitting(false);
+		}
+	}
+
+	return (
+		<>
+			<button
+				type="button"
+				onClick={handleOpen}
+				className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-destructive"
+				aria-label="通報する"
+			>
+				<Flag size={14} />
+				<span>通報</span>
+			</button>
+
+			{isOpen && (
+				<div
+					role="dialog"
+					className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+					onClick={(e) => {
+						if (e.target === e.currentTarget) handleClose();
+					}}
+					onKeyDown={(e) => {
+						if (e.key === 'Escape') handleClose();
+					}}
+				>
+					<div className="mx-4 w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
+						<div className="flex items-center justify-between">
+							<h3 className="text-lg font-bold text-foreground">
+								{targetType === 'article' ? '記事' : 'コメント'}を通報
+							</h3>
+							<button
+								type="button"
+								onClick={handleClose}
+								className="text-muted-foreground transition-colors hover:text-foreground"
+								aria-label="閉じる"
+							>
+								<X size={20} />
+							</button>
+						</div>
+
+						{successMessage ? (
+							<div className="mt-4 rounded-md border border-primary/50 bg-primary/10 px-4 py-3 text-sm text-primary">
+								{successMessage}
+							</div>
+						) : (
+							<form onSubmit={handleSubmit} className="mt-4 space-y-4">
+								{errorMessage && (
+									<div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+										{errorMessage}
+									</div>
+								)}
+
+								<fieldset>
+									<legend className="mb-2 text-sm font-medium text-foreground">通報理由</legend>
+									<div className="space-y-2">
+										{(Object.entries(REASON_LABELS) as [ReportReason, string][]).map(
+											([value, label]) => (
+												<label
+													key={value}
+													className="flex items-center gap-2 text-sm text-foreground"
+												>
+													<input
+														type="radio"
+														name="reason"
+														value={value}
+														checked={reason === value}
+														onChange={() => setReason(value)}
+														className="accent-primary"
+													/>
+													{label}
+												</label>
+											),
+										)}
+									</div>
+								</fieldset>
+
+								<div>
+									<label
+										htmlFor="report-description"
+										className="mb-1 block text-sm font-medium text-foreground"
+									>
+										詳細説明（任意）
+									</label>
+									<textarea
+										id="report-description"
+										value={description}
+										onChange={(e) => setDescription(e.target.value)}
+										maxLength={1000}
+										rows={3}
+										placeholder="詳しい内容を入力してください..."
+										className="w-full resize-none rounded-lg border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+									/>
+									<p className="mt-1 text-xs text-muted-foreground">{description.length}/1000</p>
+								</div>
+
+								<div className="flex justify-end gap-2">
+									<button
+										type="button"
+										onClick={handleClose}
+										disabled={isSubmitting}
+										className="rounded-md border border-border bg-card px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+									>
+										キャンセル
+									</button>
+									<button
+										type="submit"
+										disabled={isSubmitting || !reason}
+										className="inline-flex items-center gap-1.5 rounded-md bg-destructive px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-destructive/90 disabled:cursor-not-allowed disabled:opacity-50"
+									>
+										{isSubmitting ? (
+											<>
+												<Loader2 size={14} className="animate-spin" />
+												送信中...
+											</>
+										) : (
+											'通報する'
+										)}
+									</button>
+								</div>
+							</form>
+						)}
+					</div>
+				</div>
+			)}
+		</>
+	);
+}

--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import ReportButton from '../ReportButton';
 
 interface Comment {
 	id: string;
@@ -178,6 +179,12 @@ export default function CommentSection({
 		return false;
 	}
 
+	function canReport(comment: Comment): boolean {
+		if (!currentUser) return false;
+		if (currentUser.id === comment.author.id) return false;
+		return true;
+	}
+
 	useEffect(() => {
 		loadInitialComments();
 	}, [loadInitialComments]);
@@ -224,15 +231,24 @@ export default function CommentSection({
 										{formatRelativeTime(comment.createdAt)}
 									</span>
 								</div>
-								{canDelete(comment) && (
-									<button
-										type="button"
-										onClick={() => handleDelete(comment.id)}
-										className="text-xs text-muted-foreground transition-colors hover:text-destructive"
-									>
-										削除
-									</button>
-								)}
+								<div className="flex items-center gap-2">
+									{canReport(comment) && (
+										<ReportButton
+											targetType="comment"
+											targetId={comment.id}
+											isLoggedIn={!!currentUser}
+										/>
+									)}
+									{canDelete(comment) && (
+										<button
+											type="button"
+											onClick={() => handleDelete(comment.id)}
+											className="text-xs text-muted-foreground transition-colors hover:text-destructive"
+										>
+											削除
+										</button>
+									)}
+								</div>
 							</div>
 							<p className="mt-2 whitespace-pre-wrap text-sm text-foreground">{comment.body}</p>
 						</div>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -82,3 +82,23 @@ export const reactions = pgTable(
 	},
 	(t) => [primaryKey({ columns: [t.articleId, t.userId] })],
 );
+
+// 通報
+export const reports = pgTable('reports', {
+	id: uuid('id').defaultRandom().primaryKey(),
+	reason: text('reason', {
+		enum: ['spam', 'inappropriate', 'misleading', 'other'],
+	}).notNull(),
+	description: text('description'),
+	targetType: text('target_type', { enum: ['article', 'comment'] }).notNull(),
+	targetId: uuid('target_id').notNull(),
+	reporterId: uuid('reporter_id')
+		.references(() => profiles.id)
+		.notNull(),
+	status: text('status', { enum: ['pending', 'resolved', 'dismissed'] })
+		.default('pending')
+		.notNull(),
+	resolvedBy: uuid('resolved_by').references(() => profiles.id),
+	resolvedAt: timestamp('resolved_at'),
+	createdAt: timestamp('created_at').defaultNow().notNull(),
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,10 @@
-type ErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'UNAUTHORIZED' | 'FORBIDDEN' | 'INTERNAL_ERROR';
+type ErrorCode =
+	| 'VALIDATION_ERROR'
+	| 'NOT_FOUND'
+	| 'UNAUTHORIZED'
+	| 'FORBIDDEN'
+	| 'INTERNAL_ERROR'
+	| 'RATE_LIMITED';
 
 interface ErrorBody {
 	error: {
@@ -36,4 +42,20 @@ export function unauthorized(message = 'Authentication required'): Response {
 
 export function forbidden(message = 'Permission denied'): Response {
 	return errorResponse(403, 'FORBIDDEN', message);
+}
+
+export function rateLimitError(retryAfter: number): Response {
+	const body: ErrorBody = {
+		error: {
+			code: 'RATE_LIMITED',
+			message: 'Too many requests. Please try again later.',
+		},
+	};
+	return new Response(JSON.stringify(body), {
+		status: 429,
+		headers: {
+			'Content-Type': 'application/json',
+			'Retry-After': String(retryAfter),
+		},
+	});
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,96 @@
+const RATE_LIMITS: Record<string, { window: number; max: number }> = {
+	'POST /api/articles': { window: 3600, max: 10 },
+	'POST /api/articles/*/comments': { window: 60, max: 5 },
+	'POST /api/reports': { window: 3600, max: 20 },
+	'POST /api/images/upload': { window: 3600, max: 30 },
+};
+
+function matchRateLimitKey(
+	method: string,
+	path: string,
+): { key: string; limit: { window: number; max: number } } | null {
+	for (const [pattern, limit] of Object.entries(RATE_LIMITS)) {
+		const [patternMethod, ...patternPathParts] = pattern.split(' ');
+		const patternPath = patternPathParts.join(' ');
+
+		if (method !== patternMethod) continue;
+
+		const regex = new RegExp(`^${patternPath.replace(/\*/g, '[^/]+')}$`);
+		if (regex.test(path)) {
+			return { key: pattern, limit };
+		}
+	}
+	return null;
+}
+
+function buildCacheUrl(method: string, path: string, identifier: string): string {
+	return `https://rate-limit.internal/${method}/${path}/${identifier}`;
+}
+
+export async function checkRateLimit(
+	key: string,
+	limit: { window: number; max: number },
+): Promise<{ allowed: boolean; remaining: number; resetAt: number }> {
+	const cache = (caches as unknown as { default: Cache }).default;
+	const cacheUrl = new Request(key);
+
+	const cached = await cache.match(cacheUrl);
+	const now = Math.floor(Date.now() / 1000);
+
+	if (cached) {
+		const data = (await cached.json()) as { count: number; resetAt: number };
+
+		if (now >= data.resetAt) {
+			const resetAt = now + limit.window;
+			const response = new Response(JSON.stringify({ count: 1, resetAt }), {
+				headers: {
+					'Content-Type': 'application/json',
+					'Cache-Control': `s-maxage=${limit.window}`,
+				},
+			});
+			await cache.put(cacheUrl, response);
+			return { allowed: true, remaining: limit.max - 1, resetAt };
+		}
+
+		const newCount = data.count + 1;
+		const ttl = data.resetAt - now;
+
+		if (newCount > limit.max) {
+			return { allowed: false, remaining: 0, resetAt: data.resetAt };
+		}
+
+		const response = new Response(JSON.stringify({ count: newCount, resetAt: data.resetAt }), {
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': `s-maxage=${ttl}`,
+			},
+		});
+		await cache.put(cacheUrl, response);
+		return {
+			allowed: true,
+			remaining: limit.max - newCount,
+			resetAt: data.resetAt,
+		};
+	}
+
+	const resetAt = now + limit.window;
+	const response = new Response(JSON.stringify({ count: 1, resetAt }), {
+		headers: {
+			'Content-Type': 'application/json',
+			'Cache-Control': `s-maxage=${limit.window}`,
+		},
+	});
+	await cache.put(cacheUrl, response);
+	return { allowed: true, remaining: limit.max - 1, resetAt };
+}
+
+export function getRateLimitConfig(
+	method: string,
+	path: string,
+): { key: string; limit: { window: number; max: number } } | null {
+	return matchRateLimitKey(method, path);
+}
+
+export function buildRateLimitKey(method: string, path: string, identifier: string): string {
+	return buildCacheUrl(method, path, identifier);
+}

--- a/src/lib/reports.ts
+++ b/src/lib/reports.ts
@@ -1,0 +1,104 @@
+import { and, count, desc, eq } from 'drizzle-orm';
+import type { Database } from '../db';
+import { reports } from '../db/schema';
+
+export interface CreateReportData {
+	reason: 'spam' | 'inappropriate' | 'misleading' | 'other';
+	description?: string;
+	targetType: 'article' | 'comment';
+	targetId: string;
+}
+
+export interface ListReportsOptions {
+	status?: 'pending' | 'resolved' | 'dismissed';
+	page?: number;
+	limit?: number;
+}
+
+export async function createReport(db: Database, data: CreateReportData, reporterId: string) {
+	// 重複チェック: 同じユーザーが同じ targetType + targetId を重複通報できない
+	const existing = await db
+		.select({ id: reports.id })
+		.from(reports)
+		.where(
+			and(
+				eq(reports.reporterId, reporterId),
+				eq(reports.targetType, data.targetType),
+				eq(reports.targetId, data.targetId),
+			),
+		)
+		.limit(1);
+
+	if (existing.length > 0) {
+		return { duplicate: true, data: null } as const;
+	}
+
+	const [inserted] = await db
+		.insert(reports)
+		.values({
+			reason: data.reason,
+			description: data.description ?? null,
+			targetType: data.targetType,
+			targetId: data.targetId,
+			reporterId,
+		})
+		.returning();
+
+	return { duplicate: false, data: inserted } as const;
+}
+
+export async function listReports(db: Database, options: ListReportsOptions = {}) {
+	const page = Math.max(1, options.page ?? 1);
+	const limit = Math.min(100, Math.max(1, options.limit ?? 20));
+	const offset = (page - 1) * limit;
+
+	const conditions = [];
+	if (options.status) {
+		conditions.push(eq(reports.status, options.status));
+	}
+
+	const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+	const totalResult = await db.select({ total: count() }).from(reports).where(where);
+
+	const rows = await db
+		.select()
+		.from(reports)
+		.where(where)
+		.orderBy(desc(reports.createdAt))
+		.limit(limit)
+		.offset(offset);
+
+	const total = totalResult[0]?.total ?? 0;
+
+	return { data: rows, meta: { page, limit, total } };
+}
+
+export async function updateReportStatus(
+	db: Database,
+	id: string,
+	status: 'resolved' | 'dismissed',
+	resolvedBy: string,
+) {
+	const existing = await db
+		.select({ id: reports.id })
+		.from(reports)
+		.where(eq(reports.id, id))
+		.limit(1);
+
+	if (existing.length === 0) {
+		return null;
+	}
+
+	const [updated] = await db
+		.update(reports)
+		.set({
+			status,
+			resolvedBy,
+			resolvedAt: new Date(),
+		})
+		.where(eq(reports.id, id))
+		.returning();
+
+	return updated;
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -20,6 +20,17 @@ export interface UpdateArticleInput {
 	status?: 'draft' | 'published';
 }
 
+export interface CreateReportInput {
+	reason: 'spam' | 'inappropriate' | 'misleading' | 'other';
+	description?: string;
+	targetType: 'article' | 'comment';
+	targetId: string;
+}
+
+export interface UpdateReportInput {
+	status: 'resolved' | 'dismissed';
+}
+
 export function validateCreateArticle(data: unknown): ValidationResult<CreateArticleInput> {
 	if (typeof data !== 'object' || data === null) {
 		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
@@ -173,6 +184,100 @@ export function validateCreateComment(data: unknown): ValidationResult<CreateCom
 		success: true,
 		data: {
 			body: obj.body as string,
+		},
+	};
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const REPORT_REASONS = ['spam', 'inappropriate', 'misleading', 'other'] as const;
+const TARGET_TYPES = ['article', 'comment'] as const;
+
+export function validateCreateReport(data: unknown): ValidationResult<CreateReportInput> {
+	if (typeof data !== 'object' || data === null) {
+		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
+	}
+
+	const obj = data as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	// reason
+	if (obj.reason === undefined || obj.reason === null) {
+		errors.reason = ['reason is required'];
+	} else if (typeof obj.reason !== 'string') {
+		errors.reason = ['reason must be a string'];
+	} else if (!(REPORT_REASONS as readonly string[]).includes(obj.reason)) {
+		errors.reason = ['reason must be one of: spam, inappropriate, misleading, other'];
+	}
+
+	// targetType
+	if (obj.targetType === undefined || obj.targetType === null) {
+		errors.targetType = ['targetType is required'];
+	} else if (typeof obj.targetType !== 'string') {
+		errors.targetType = ['targetType must be a string'];
+	} else if (!(TARGET_TYPES as readonly string[]).includes(obj.targetType)) {
+		errors.targetType = ['targetType must be one of: article, comment'];
+	}
+
+	// targetId
+	if (obj.targetId === undefined || obj.targetId === null) {
+		errors.targetId = ['targetId is required'];
+	} else if (typeof obj.targetId !== 'string') {
+		errors.targetId = ['targetId must be a string'];
+	} else if (!UUID_REGEX.test(obj.targetId)) {
+		errors.targetId = ['targetId must be a valid UUID'];
+	}
+
+	// description (optional)
+	if (obj.description !== undefined && obj.description !== null) {
+		if (typeof obj.description !== 'string') {
+			errors.description = ['description must be a string'];
+		} else if (obj.description.length > 1000) {
+			errors.description = ['description must be at most 1000 characters'];
+		}
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { success: false, errors };
+	}
+
+	return {
+		success: true,
+		data: {
+			reason: obj.reason as CreateReportInput['reason'],
+			targetType: obj.targetType as CreateReportInput['targetType'],
+			targetId: obj.targetId as string,
+			description: (obj.description as string) ?? undefined,
+		},
+	};
+}
+
+const REPORT_STATUSES = ['resolved', 'dismissed'] as const;
+
+export function validateUpdateReport(data: unknown): ValidationResult<UpdateReportInput> {
+	if (typeof data !== 'object' || data === null) {
+		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
+	}
+
+	const obj = data as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	// status
+	if (obj.status === undefined || obj.status === null) {
+		errors.status = ['status is required'];
+	} else if (typeof obj.status !== 'string') {
+		errors.status = ['status must be a string'];
+	} else if (!(REPORT_STATUSES as readonly string[]).includes(obj.status)) {
+		errors.status = ['status must be one of: resolved, dismissed'];
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { success: false, errors };
+	}
+
+	return {
+		success: true,
+		data: {
+			status: obj.status as UpdateReportInput['status'],
 		},
 	};
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,8 @@ import { defineMiddleware } from 'astro:middleware';
 import { eq } from 'drizzle-orm';
 import { createDb } from './db';
 import { profiles } from './db/schema';
+import { rateLimitError } from './lib/errors';
+import { buildRateLimitKey, checkRateLimit, getRateLimitConfig } from './lib/rate-limit';
 import { createSupabaseClient } from './lib/supabase';
 
 const ONBOARDING_SKIP_PATHS = ['/onboarding', '/api/', '/login', '/register'];
@@ -42,6 +44,36 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		}
 	} else {
 		context.locals.currentUser = null;
+	}
+
+	// Rate limiting for POST requests
+	const method = context.request.method;
+	const path = context.url.pathname;
+
+	if (method === 'POST') {
+		const config = getRateLimitConfig(method, path);
+		if (config) {
+			const ip =
+				context.request.headers.get('cf-connecting-ip') ??
+				context.request.headers.get('x-forwarded-for') ??
+				'unknown';
+			const userId = user?.id ?? '';
+			const identifier = userId ? `${ip}:${userId}` : ip;
+			const cacheKey = buildRateLimitKey(method, path, identifier);
+
+			const result = await checkRateLimit(cacheKey, config.limit);
+			const now = Math.floor(Date.now() / 1000);
+			const retryAfter = Math.max(0, result.resetAt - now);
+
+			if (!result.allowed) {
+				return rateLimitError(retryAfter);
+			}
+
+			const response = await next();
+			response.headers.set('X-RateLimit-Remaining', String(result.remaining));
+			response.headers.set('X-RateLimit-Reset', String(result.resetAt));
+			return response;
+		}
 	}
 
 	return next();

--- a/src/pages/api/admin/articles/[slug].ts
+++ b/src/pages/api/admin/articles/[slug].ts
@@ -1,0 +1,25 @@
+import type { APIContext } from 'astro';
+import { deleteArticle, getArticleBySlug } from '../../../../lib/articles';
+import { forbidden, notFound, unauthorized } from '../../../../lib/errors';
+
+export async function DELETE(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const slug = context.params.slug as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	const article = await getArticleBySlug(db, slug);
+	if (!article) {
+		return notFound('Article not found');
+	}
+
+	await deleteArticle(db, article.id);
+
+	return new Response(null, { status: 204 });
+}

--- a/src/pages/api/reports/[id].ts
+++ b/src/pages/api/reports/[id].ts
@@ -1,0 +1,41 @@
+import type { APIContext } from 'astro';
+import { forbidden, notFound, unauthorized, validationError } from '../../../lib/errors';
+import { updateReportStatus } from '../../../lib/reports';
+import { validateUpdateReport } from '../../../lib/validation';
+
+export async function PUT(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const id = context.params.id as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	let body: unknown;
+	try {
+		body = await context.request.json();
+	} catch {
+		return validationError({ _: ['Request body must be valid JSON'] });
+	}
+
+	const validation = validateUpdateReport(body);
+
+	if (!validation.success) {
+		return validationError(validation.errors);
+	}
+
+	const updated = await updateReportStatus(db, id, validation.data.status, currentUser.id);
+
+	if (!updated) {
+		return notFound('Report not found');
+	}
+
+	return new Response(JSON.stringify({ data: updated }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/src/pages/api/reports/index.ts
+++ b/src/pages/api/reports/index.ts
@@ -1,0 +1,67 @@
+import type { APIContext } from 'astro';
+import { errorResponse, forbidden, unauthorized, validationError } from '../../../lib/errors';
+import { createReport, listReports } from '../../../lib/reports';
+import { validateCreateReport } from '../../../lib/validation';
+
+export async function POST(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	let body: unknown;
+	try {
+		body = await context.request.json();
+	} catch {
+		return validationError({ _: ['Request body must be valid JSON'] });
+	}
+
+	const validation = validateCreateReport(body);
+
+	if (!validation.success) {
+		return validationError(validation.errors);
+	}
+
+	const result = await createReport(db, validation.data, currentUser.id);
+
+	if (result.duplicate) {
+		return errorResponse(409, 'VALIDATION_ERROR', 'You have already reported this content');
+	}
+
+	return new Response(JSON.stringify({ data: result.data }), {
+		status: 201,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	const params = context.url.searchParams;
+	const page = Number(params.get('page') ?? '1');
+	const limit = Number(params.get('limit') ?? '20');
+
+	const validStatuses = ['pending', 'resolved', 'dismissed'] as const;
+	const rawStatus = params.get('status');
+	let status: (typeof validStatuses)[number] | undefined;
+
+	if (rawStatus && validStatuses.includes(rawStatus as (typeof validStatuses)[number])) {
+		status = rawStatus as (typeof validStatuses)[number];
+	}
+
+	const result = await listReports(db, { status, page, limit });
+
+	return new Response(JSON.stringify(result), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -96,7 +96,7 @@ const canEdit = currentUser?.id === article.author.id || currentUser?.profile?.r
 			)}
 		</header>
 
-		<ArticleContent html={html} />
+		<ArticleContent html={html} articleId={article.id} isLoggedIn={!!currentUser} />
 
 		<div class="mt-8 flex justify-start">
 			<ReactionButton


### PR DESCRIPTION
## Summary

Closes #14

- 通報機能: 記事・コメントへの通報 API（`POST /api/reports`）、管理者向け通報一覧・対応 API（`GET /api/reports`, `PUT /api/reports/[id]`）
- 管理者による記事強制削除 API（`DELETE /api/admin/articles/[slug]`）
- レート制限: 主要 POST エンドポイントに Cloudflare Cache API ベースのレート制限を適用（429 レスポンス）
- 通報 UI: 記事詳細・コメントに通報ボタン（理由選択ダイアログ付き）を追加
- `reports` テーブルのマイグレーション生成

## Test plan

- [ ] `pnpm astro check` がエラーなく通る
- [ ] `pnpm biome check .` がエラーなく通る
- [ ] `POST /api/reports` で記事・コメントを通報できる
- [ ] 同じユーザーが同じ対象を重複通報すると 409 が返る
- [ ] admin が `GET /api/reports` で通報一覧を取得できる
- [ ] admin が `PUT /api/reports/[id]` で通報を解決/却下できる
- [ ] admin が `DELETE /api/admin/articles/[slug]` で記事を強制削除できる
- [ ] 非 admin ユーザーが管理者 API にアクセスすると 403 が返る
- [ ] レート制限超過時に 429 が返り、`Retry-After` ヘッダーが含まれる
- [ ] 記事詳細ページに通報ボタンが表示される
- [ ] コメントに通報ボタンが表示される（自分のコメントには非表示）
- [ ] 未ログイン時は通報ボタンが非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)