### PR TITLE
fix: 通報機能のreportsテーブル未作成とエラーメッセージ取得を修正 (#65)

### DIFF
--- a/drizzle/0002_create_reports_table.sql
+++ b/drizzle/0002_create_reports_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"reason" text NOT NULL,
+	"description" text,
+	"target_type" text NOT NULL,
+	"target_id" uuid NOT NULL,
+	"reporter_id" uuid NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"resolved_by" uuid,
+	"resolved_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "reports" ADD CONSTRAINT "reports_reporter_id_profiles_id_fk" FOREIGN KEY ("reporter_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reports" ADD CONSTRAINT "reports_resolved_by_profiles_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1772589200718,
 			"tag": "0000_perpetual_moondragon",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1772589200720,
+			"tag": "0002_create_reports_table",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -72,7 +72,7 @@ export default function ReportButton({ targetType, targetId, isLoggedIn }: Repor
 				if (res.status === 409) {
 					setErrorMessage('すでに通報済みです');
 				} else {
-					setErrorMessage(json?.error ?? '通報の送信に失敗しました');
+					setErrorMessage(json?.error?.message ?? '通報の送信に失敗しました');
 				}
 				return;
 			}


### PR DESCRIPTION
## Summary

Closes #65

- `reports` テーブルの個別マイグレーション (`drizzle/0002_create_reports_table.sql`) を追加。`0000` の初期マイグレーションは既存テーブルと衝突するため適用不可だったが、`CREATE TABLE IF NOT EXISTS` で安全に適用可能に
- `ReportButton.tsx` のエラーメッセージ取得を修正: `json?.error`（オブジェクト）→ `json?.error?.message`（文字列）

## Test plan

- [ ] `pnpm astro check` がエラーなく通る
- [ ] `pnpm biome check .` がエラーなく通る
- [ ] マイグレーション適用後、`POST /api/reports` で通報が正常に送信できる
- [ ] API エラー時にサーバーからのエラーメッセージが正しく表示される
- [ ] 重複通報時に「すでに通報済みです」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)