### PR TITLE
feat: モデレーション機能（admin権限付与・記事/コメント削除・管理画面）を実装 (#53)

### DIFF
--- a/src/components/ArticleDeleteButton.tsx
+++ b/src/components/ArticleDeleteButton.tsx
@@ -1,0 +1,55 @@
+import { Loader2, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface Props {
+	slug: string;
+}
+
+export default function ArticleDeleteButton({ slug }: Props) {
+	const [isDeleting, setIsDeleting] = useState(false);
+
+	async function handleDelete() {
+		if (!window.confirm('この記事を削除しますか？')) {
+			return;
+		}
+
+		setIsDeleting(true);
+
+		try {
+			const res = await fetch(`/api/admin/articles/${slug}`, {
+				method: 'DELETE',
+			});
+
+			if (!res.ok) {
+				const json = await res.json().catch(() => null);
+				throw new Error(json?.error ?? '記事の削除に失敗しました');
+			}
+
+			window.location.href = '/';
+		} catch (err) {
+			alert(err instanceof Error ? err.message : '記事の削除に失敗しました');
+			setIsDeleting(false);
+		}
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={handleDelete}
+			disabled={isDeleting}
+			className="inline-flex items-center gap-1.5 shrink-0 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-1.5 text-sm font-medium text-destructive shadow-xs hover:bg-destructive hover:text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+		>
+			{isDeleting ? (
+				<>
+					<Loader2 size={16} className="animate-spin" />
+					削除中...
+				</>
+			) : (
+				<>
+					<Trash2 size={16} />
+					削除
+				</>
+			)}
+		</button>
+	);
+}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -51,6 +51,7 @@ const currentUser = Astro.locals.currentUser;
 								client:load
 								displayName={currentUser.profile?.displayName ?? currentUser.email}
 								avatarUrl={currentUser.profile?.avatarUrl ?? undefined}
+								role={currentUser.profile?.role ?? undefined}
 							/>
 						</>
 					) : (
@@ -71,6 +72,7 @@ const currentUser = Astro.locals.currentUser;
 				user={currentUser ? {
 					displayName: currentUser.profile?.displayName ?? currentUser.email,
 					avatarUrl: currentUser.profile?.avatarUrl ?? undefined,
+					role: currentUser.profile?.role ?? undefined,
 				} : null}
 			/>
 		</div>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,8 +1,8 @@
-import { LogOut, Menu, Search, Settings, User, X } from 'lucide-react';
+import { LogOut, Menu, Search, Settings, Shield, User, X } from 'lucide-react';
 import { useState } from 'react';
 
 interface Props {
-	user: { displayName: string; avatarUrl?: string } | null;
+	user: { displayName: string; avatarUrl?: string; role?: string } | null;
 }
 
 export default function MobileNav({ user }: Props) {
@@ -74,6 +74,16 @@ export default function MobileNav({ user }: Props) {
 									)}
 									<span className="text-foreground text-sm">{user.displayName}</span>
 								</div>
+								{user.role === 'admin' && (
+									<a
+										href="/admin"
+										className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors py-2"
+										onClick={() => setIsOpen(false)}
+									>
+										<Shield size={16} />
+										管理画面
+									</a>
+								)}
 								<a
 									href="/settings/profile"
 									className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors py-2"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,12 +1,13 @@
-import { ChevronDown, LogOut, Settings, User } from 'lucide-react';
+import { ChevronDown, LogOut, Settings, Shield, User } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 interface Props {
 	displayName: string;
 	avatarUrl?: string;
+	role?: string;
 }
 
-export default function UserMenu({ displayName, avatarUrl }: Props) {
+export default function UserMenu({ displayName, avatarUrl, role }: Props) {
 	const [isOpen, setIsOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
 
@@ -40,9 +41,18 @@ export default function UserMenu({ displayName, avatarUrl }: Props) {
 
 			{isOpen && (
 				<div className="absolute right-0 mt-2 w-48 bg-card border border-border rounded-md shadow-lg z-50">
+					{role === 'admin' && (
+						<a
+							href="/admin"
+							className="w-full flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors rounded-t-md"
+						>
+							<Shield size={16} />
+							管理画面
+						</a>
+					)}
 					<a
 						href="/settings/profile"
-						className="w-full flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors rounded-t-md"
+						className={`w-full flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors ${role !== 'admin' ? 'rounded-t-md' : ''}`}
 					>
 						<Settings size={16} />
 						プロフィール設定

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface User {
+	id: string;
+	username: string;
+	displayName: string;
+	avatarUrl: string | null;
+	role: 'user' | 'moderator' | 'admin';
+	createdAt: string;
+}
+
+interface Props {
+	currentUserId: string;
+}
+
+export default function UserManagement({ currentUserId }: Props) {
+	const [users, setUsers] = useState<User[]>([]);
+	const [total, setTotal] = useState(0);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+	const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+
+	const fetchUsers = useCallback(async () => {
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			const res = await fetch('/api/admin/users');
+			if (!res.ok) {
+				throw new Error('ユーザー一覧の取得に失敗しました');
+			}
+			const json = await res.json();
+			setUsers(json.users);
+			setTotal(json.total);
+		} catch {
+			setError('ユーザー一覧の取得に失敗しました');
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		fetchUsers();
+	}, [fetchUsers]);
+
+	useEffect(() => {
+		if (toast) {
+			const timer = setTimeout(() => setToast(null), 3000);
+			return () => clearTimeout(timer);
+		}
+	}, [toast]);
+
+	async function handleRoleChange(userId: string, newRole: string) {
+		setUpdatingUserId(userId);
+
+		try {
+			const res = await fetch(`/api/admin/users/${userId}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ role: newRole }),
+			});
+
+			if (!res.ok) {
+				const json = await res.json().catch(() => null);
+				throw new Error(json?.error ?? 'ロールの変更に失敗しました');
+			}
+
+			const json = await res.json();
+			setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, role: json.user.role } : u)));
+			setToast({ message: 'ロールを変更しました', type: 'success' });
+		} catch (err) {
+			setToast({
+				message: err instanceof Error ? err.message : 'ロールの変更に失敗しました',
+				type: 'error',
+			});
+		} finally {
+			setUpdatingUserId(null);
+		}
+	}
+
+	function formatDate(dateString: string): string {
+		return new Date(dateString).toLocaleDateString('ja-JP', {
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit',
+		});
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center py-12">
+				<p className="text-sm text-muted-foreground">読み込み中...</p>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+				{error}
+				<button type="button" onClick={fetchUsers} className="ml-2 underline hover:no-underline">
+					再読み込み
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			{/* トースト */}
+			{toast && (
+				<div
+					className={`fixed top-4 right-4 z-50 rounded-md px-4 py-3 text-sm shadow-lg transition-all ${
+						toast.type === 'success'
+							? 'border border-primary/50 bg-primary/10 text-primary'
+							: 'border border-destructive/50 bg-destructive/10 text-destructive'
+					}`}
+				>
+					{toast.message}
+				</div>
+			)}
+
+			<div className="rounded-lg border border-border bg-card">
+				<div className="border-b border-border px-4 py-3">
+					<h2 className="text-lg font-bold text-foreground">ユーザー管理 ({total}人)</h2>
+				</div>
+
+				{/* デスクトップ: テーブル表示 */}
+				<div className="hidden md:block overflow-x-auto">
+					<table className="w-full">
+						<thead>
+							<tr className="border-b border-border text-left text-sm text-muted-foreground">
+								<th className="px-4 py-3 font-medium">ユーザー</th>
+								<th className="px-4 py-3 font-medium">ユーザー名</th>
+								<th className="px-4 py-3 font-medium">ロール</th>
+								<th className="px-4 py-3 font-medium">作成日</th>
+							</tr>
+						</thead>
+						<tbody>
+							{users.map((user) => (
+								<tr
+									key={user.id}
+									className="border-b border-border last:border-b-0 hover:bg-muted/50 transition-colors"
+								>
+									<td className="px-4 py-3">
+										<div className="flex items-center gap-3">
+											{user.avatarUrl ? (
+												<img
+													src={user.avatarUrl}
+													alt={user.displayName}
+													className="h-8 w-8 rounded-full object-cover"
+													loading="lazy"
+												/>
+											) : (
+												<span className="flex h-8 w-8 items-center justify-center rounded-full bg-secondary text-sm font-medium">
+													{user.displayName.charAt(0)}
+												</span>
+											)}
+											<span className="text-sm font-medium text-foreground">
+												{user.displayName}
+											</span>
+										</div>
+									</td>
+									<td className="px-4 py-3">
+										<span className="text-sm text-muted-foreground">@{user.username}</span>
+									</td>
+									<td className="px-4 py-3">
+										<select
+											value={user.role}
+											onChange={(e) => handleRoleChange(user.id, e.target.value)}
+											disabled={user.id === currentUserId || updatingUserId === user.id}
+											className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+										>
+											<option value="user">ユーザー</option>
+											<option value="moderator">モデレーター</option>
+											<option value="admin">管理者</option>
+										</select>
+										{user.id === currentUserId && (
+											<span className="ml-2 text-xs text-muted-foreground">(自分)</span>
+										)}
+									</td>
+									<td className="px-4 py-3">
+										<span className="text-sm text-muted-foreground">
+											{formatDate(user.createdAt)}
+										</span>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+
+				{/* モバイル: カード表示 */}
+				<div className="md:hidden divide-y divide-border">
+					{users.map((user) => (
+						<div key={user.id} className="p-4 space-y-3">
+							<div className="flex items-center gap-3">
+								{user.avatarUrl ? (
+									<img
+										src={user.avatarUrl}
+										alt={user.displayName}
+										className="h-10 w-10 rounded-full object-cover"
+										loading="lazy"
+									/>
+								) : (
+									<span className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-sm font-medium">
+										{user.displayName.charAt(0)}
+									</span>
+								)}
+								<div>
+									<p className="text-sm font-medium text-foreground">{user.displayName}</p>
+									<p className="text-xs text-muted-foreground">@{user.username}</p>
+								</div>
+							</div>
+							<div className="flex items-center justify-between">
+								<div className="flex items-center gap-2">
+									<span className="text-xs text-muted-foreground">ロール:</span>
+									<select
+										value={user.role}
+										onChange={(e) => handleRoleChange(user.id, e.target.value)}
+										disabled={user.id === currentUserId || updatingUserId === user.id}
+										className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+									>
+										<option value="user">ユーザー</option>
+										<option value="moderator">モデレーター</option>
+										<option value="admin">管理者</option>
+									</select>
+									{user.id === currentUserId && (
+										<span className="text-xs text-muted-foreground">(自分)</span>
+									)}
+								</div>
+								<span className="text-xs text-muted-foreground">{formatDate(user.createdAt)}</span>
+							</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,18 @@
+---
+import UserManagement from '../../components/admin/UserManagement.tsx';
+import Layout from '../../layouts/Layout.astro';
+
+const currentUser = Astro.locals.currentUser;
+
+// admin以外はリダイレクト
+if (!currentUser || currentUser.profile?.role !== 'admin') {
+	return Astro.redirect('/');
+}
+---
+
+<Layout title="管理画面">
+	<div class="py-8 max-w-4xl mx-auto">
+		<h1 class="text-3xl font-bold text-foreground mb-8">管理画面</h1>
+		<UserManagement client:load currentUserId={currentUser.id} />
+	</div>
+</Layout>

--- a/src/pages/api/admin/users/[id].ts
+++ b/src/pages/api/admin/users/[id].ts
@@ -1,0 +1,84 @@
+import type { APIContext } from 'astro';
+import { count as countFn, eq } from 'drizzle-orm';
+import { profiles } from '../../../../db/schema';
+import {
+	errorResponse,
+	forbidden,
+	notFound,
+	unauthorized,
+	validationError,
+} from '../../../../lib/errors';
+
+const VALID_ROLES = ['user', 'moderator', 'admin'] as const;
+type Role = (typeof VALID_ROLES)[number];
+
+export async function PATCH(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const targetId = context.params.id as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	let body: unknown;
+	try {
+		body = await context.request.json();
+	} catch {
+		return validationError({ _: ['Request body must be valid JSON'] });
+	}
+
+	const { role } = body as { role?: string };
+
+	if (!role || !VALID_ROLES.includes(role as Role)) {
+		return validationError({ role: ['Role must be one of: user, moderator, admin'] });
+	}
+
+	const newRole = role as Role;
+
+	// 自分自身のadmin権限剥奪を禁止
+	if (targetId === currentUser.id && newRole !== 'admin') {
+		return errorResponse(400, 'VALIDATION_ERROR', 'Cannot remove your own admin role');
+	}
+
+	// 対象ユーザーの存在確認
+	const [targetUser] = await db.select().from(profiles).where(eq(profiles.id, targetId)).limit(1);
+
+	if (!targetUser) {
+		return notFound('User not found');
+	}
+
+	// 最低1人のadmin保証
+	if (targetUser.role === 'admin' && newRole !== 'admin') {
+		const [adminCount] = await db
+			.select({ count: countFn() })
+			.from(profiles)
+			.where(eq(profiles.role, 'admin'));
+
+		if (adminCount.count <= 1) {
+			return errorResponse(400, 'VALIDATION_ERROR', 'At least one admin must exist');
+		}
+	}
+
+	// role更新
+	const [updatedUser] = await db
+		.update(profiles)
+		.set({ role: newRole, updatedAt: new Date() })
+		.where(eq(profiles.id, targetId))
+		.returning({
+			id: profiles.id,
+			username: profiles.username,
+			displayName: profiles.displayName,
+			avatarUrl: profiles.avatarUrl,
+			role: profiles.role,
+			createdAt: profiles.createdAt,
+		});
+
+	return new Response(JSON.stringify({ user: updatedUser }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/src/pages/api/admin/users/index.ts
+++ b/src/pages/api/admin/users/index.ts
@@ -1,0 +1,42 @@
+import type { APIContext } from 'astro';
+import { count as countFn } from 'drizzle-orm';
+import { profiles } from '../../../../db/schema';
+import { forbidden, unauthorized } from '../../../../lib/errors';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	const params = context.url.searchParams;
+	const limit = Math.min(100, Math.max(1, Number(params.get('limit') ?? '50')));
+	const offset = Math.max(0, Number(params.get('offset') ?? '0'));
+
+	const [users, totalResult] = await Promise.all([
+		db
+			.select({
+				id: profiles.id,
+				username: profiles.username,
+				displayName: profiles.displayName,
+				avatarUrl: profiles.avatarUrl,
+				role: profiles.role,
+				createdAt: profiles.createdAt,
+			})
+			.from(profiles)
+			.limit(limit)
+			.offset(offset)
+			.orderBy(profiles.createdAt),
+		db.select({ count: countFn() }).from(profiles),
+	]);
+
+	return new Response(JSON.stringify({ users, total: totalResult[0].count }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { and, count as countFn, eq } from 'drizzle-orm';
 import ArticleContent from '../../components/ArticleContent.astro';
+import ArticleDeleteButton from '../../components/ArticleDeleteButton.tsx';
 import CommentSection from '../../components/comments/CommentSection.tsx';
 import ReactionButton from '../../components/ReactionButton.tsx';
 import { reactions } from '../../db/schema';
@@ -42,6 +43,7 @@ if (currentUser) {
 }
 
 const canEdit = currentUser?.id === article.author.id || currentUser?.profile?.role === 'admin';
+const isAdmin = currentUser?.profile?.role === 'admin';
 ---
 
 <Layout title={article.title} description={description}>
@@ -52,13 +54,20 @@ const canEdit = currentUser?.id === article.author.id || currentUser?.profile?.r
 					{article.title}
 				</h1>
 				{canEdit && (
-					<a
-						href={`/articles/${article.slug}/edit`}
-						class="inline-flex items-center gap-1.5 shrink-0 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground shadow-xs hover:bg-accent hover:text-accent-foreground transition-colors"
-					>
-						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
-						編集
-					</a>
+					<div class="flex items-center gap-2 shrink-0">
+						{canEdit && (
+							<a
+								href={`/articles/${article.slug}/edit`}
+								class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground shadow-xs hover:bg-accent hover:text-accent-foreground transition-colors"
+							>
+								<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+								編集
+							</a>
+						)}
+						{isAdmin && (
+							<ArticleDeleteButton client:load slug={article.slug} />
+						)}
+					</div>
 				)}
 			</div>
 


### PR DESCRIPTION
## Summary

- adminユーザーが他ユーザーにadmin/moderator権限を付与・変更できるユーザー管理APIを実装
- 管理画面（`/admin`）でユーザー一覧とrole変更が可能なUIを実装
- 記事詳細ページにadmin向け「削除」ボタンを追加
- デスクトップ・モバイル両方のナビゲーションに管理画面リンクを追加

### 新規ファイル
- `src/pages/api/admin/users/index.ts` — ユーザー一覧API（GET、admin専用）
- `src/pages/api/admin/users/[id].ts` — role変更API（PATCH、admin専用）
- `src/pages/admin/index.astro` — 管理画面ページ
- `src/components/admin/UserManagement.tsx` — ユーザー管理UIコンポーネント
- `src/components/ArticleDeleteButton.tsx` — 記事削除ボタンコンポーネント

### 編集ファイル
- `src/components/UserMenu.tsx` — admin向け管理画面リンク追加
- `src/components/MobileNav.tsx` — モバイル向け管理画面リンク追加
- `src/components/Header.astro` — role propの受け渡し追加
- `src/pages/articles/[slug].astro` — admin向け削除ボタン追加

### セキュリティ
- 全admin APIエンドポイントで認証・権限チェック実装済み
- 自分自身のadmin権限剥奪不可
- 最低1人のadminが常に存在することを保証
- admin以外のユーザーには管理機能が表示されない

Closes #53

## Test plan
- [ ] adminユーザーで `/admin` にアクセスし、ユーザー一覧が表示されること
- [ ] adminユーザーが他ユーザーのroleを変更できること
- [ ] 自分自身のrole変更が不可（ドロップダウンがdisabled）であること
- [ ] 最後のadminのrole変更がエラーになること
- [ ] admin以外のユーザーで `/admin` にアクセスするとリダイレクトされること
- [ ] 記事詳細ページにadmin向け削除ボタンが表示されること
- [ ] 記事削除が正常に動作すること
- [ ] モバイルナビゲーションにも管理画面リンクが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)