### PR TITLE
feat: admin向けタグ管理UIを実装 (#66)

### DIFF
--- a/src/components/admin/TagManagement.tsx
+++ b/src/components/admin/TagManagement.tsx
@@ -1,0 +1,438 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface Tag {
+	id: string;
+	name: string;
+	slug: string;
+	category: string;
+}
+
+type TagCategory = 'duty' | 'job' | 'crafting' | 'gathering' | 'general';
+
+const CATEGORY_LABELS: Record<string, string> = {
+	duty: 'コンテンツ',
+	job: 'ジョブ',
+	crafting: 'クラフター',
+	gathering: 'ギャザラー',
+	general: '全般',
+};
+
+const CATEGORIES: TagCategory[] = ['duty', 'job', 'crafting', 'gathering', 'general'];
+
+export default function TagManagement() {
+	const [tags, setTags] = useState<Tag[]>([]);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+	// 新規作成フォーム
+	const [showCreateForm, setShowCreateForm] = useState(false);
+	const [newName, setNewName] = useState('');
+	const [newCategory, setNewCategory] = useState<TagCategory>('general');
+	const [isCreating, setIsCreating] = useState(false);
+	const [createErrors, setCreateErrors] = useState<Record<string, string[]>>({});
+
+	// 編集状態
+	const [editingId, setEditingId] = useState<string | null>(null);
+	const [editName, setEditName] = useState('');
+	const [editCategory, setEditCategory] = useState<TagCategory>('general');
+	const [isUpdating, setIsUpdating] = useState(false);
+	const [editErrors, setEditErrors] = useState<Record<string, string[]>>({});
+
+	// 削除確認
+	const [deletingId, setDeletingId] = useState<string | null>(null);
+	const [isDeleting, setIsDeleting] = useState(false);
+
+	const fetchTags = useCallback(async () => {
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			const res = await fetch('/api/admin/tags');
+			if (!res.ok) {
+				throw new Error('タグ一覧の取得に失敗しました');
+			}
+			const json = await res.json();
+			setTags(json.tags);
+		} catch {
+			setError('タグ一覧の取得に失敗しました');
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		fetchTags();
+	}, [fetchTags]);
+
+	useEffect(() => {
+		if (toast) {
+			const timer = setTimeout(() => setToast(null), 3000);
+			return () => clearTimeout(timer);
+		}
+	}, [toast]);
+
+	async function handleCreate() {
+		setIsCreating(true);
+		setCreateErrors({});
+
+		try {
+			const res = await fetch('/api/admin/tags', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: newName, category: newCategory }),
+			});
+
+			if (!res.ok) {
+				const json = await res.json().catch(() => null);
+				if (json?.error?.details) {
+					setCreateErrors(json.error.details);
+				} else {
+					setCreateErrors({ _: [json?.error?.message ?? 'タグの作成に失敗しました'] });
+				}
+				return;
+			}
+
+			const json = await res.json();
+			setTags((prev) => [...prev, json.tag].sort((a, b) => a.name.localeCompare(b.name)));
+			setNewName('');
+			setNewCategory('general');
+			setShowCreateForm(false);
+			setToast({ message: 'タグを作成しました', type: 'success' });
+		} catch {
+			setCreateErrors({ _: ['タグの作成に失敗しました'] });
+		} finally {
+			setIsCreating(false);
+		}
+	}
+
+	function startEdit(tag: Tag) {
+		setEditingId(tag.id);
+		setEditName(tag.name);
+		setEditCategory(tag.category as TagCategory);
+		setEditErrors({});
+	}
+
+	function cancelEdit() {
+		setEditingId(null);
+		setEditErrors({});
+	}
+
+	async function handleUpdate() {
+		if (!editingId) return;
+		setIsUpdating(true);
+		setEditErrors({});
+
+		try {
+			const res = await fetch(`/api/admin/tags/${editingId}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: editName, category: editCategory }),
+			});
+
+			if (!res.ok) {
+				const json = await res.json().catch(() => null);
+				if (json?.error?.details) {
+					setEditErrors(json.error.details);
+				} else {
+					setEditErrors({ _: [json?.error?.message ?? 'タグの更新に失敗しました'] });
+				}
+				return;
+			}
+
+			const json = await res.json();
+			setTags((prev) => prev.map((t) => (t.id === editingId ? json.tag : t)));
+			setEditingId(null);
+			setToast({ message: 'タグを更新しました', type: 'success' });
+		} catch {
+			setEditErrors({ _: ['タグの更新に失敗しました'] });
+		} finally {
+			setIsUpdating(false);
+		}
+	}
+
+	async function handleDelete(id: string) {
+		setIsDeleting(true);
+
+		try {
+			const res = await fetch(`/api/admin/tags/${id}`, { method: 'DELETE' });
+			if (!res.ok) {
+				const json = await res.json().catch(() => null);
+				throw new Error(json?.error?.message ?? 'タグの削除に失敗しました');
+			}
+
+			setTags((prev) => prev.filter((t) => t.id !== id));
+			setDeletingId(null);
+			setToast({ message: 'タグを削除しました', type: 'success' });
+		} catch (err) {
+			setToast({
+				message: err instanceof Error ? err.message : 'タグの削除に失敗しました',
+				type: 'error',
+			});
+		} finally {
+			setIsDeleting(false);
+		}
+	}
+
+	// カテゴリ別にグループ化
+	const grouped = new Map<string, Tag[]>();
+	for (const tag of tags) {
+		const list = grouped.get(tag.category) ?? [];
+		list.push(tag);
+		grouped.set(tag.category, list);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center py-12">
+				<p className="text-sm text-muted-foreground">読み込み中...</p>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+				{error}
+				<button type="button" onClick={fetchTags} className="ml-2 underline hover:no-underline">
+					再読み込み
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			{/* トースト */}
+			{toast && (
+				<div
+					className={`fixed top-4 right-4 z-50 rounded-md px-4 py-3 text-sm shadow-lg transition-all ${
+						toast.type === 'success'
+							? 'border border-primary/50 bg-primary/10 text-primary'
+							: 'border border-destructive/50 bg-destructive/10 text-destructive'
+					}`}
+				>
+					{toast.message}
+				</div>
+			)}
+
+			<div className="rounded-lg border border-border bg-card">
+				<div className="border-b border-border px-4 py-3 flex items-center justify-between">
+					<h2 className="text-lg font-bold text-foreground">タグ管理 ({tags.length}件)</h2>
+					<button
+						type="button"
+						onClick={() => {
+							setShowCreateForm(!showCreateForm);
+							setCreateErrors({});
+						}}
+						className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+					>
+						{showCreateForm ? 'キャンセル' : '新規追加'}
+					</button>
+				</div>
+
+				{/* 新規作成フォーム */}
+				{showCreateForm && (
+					<div className="border-b border-border p-4 bg-muted/30">
+						<div className="space-y-3 max-w-md">
+							{createErrors._ && (
+								<p className="text-sm text-destructive">{createErrors._.join(', ')}</p>
+							)}
+							<div>
+								<label
+									htmlFor="new-tag-name"
+									className="block text-sm font-medium text-foreground mb-1"
+								>
+									タグ名
+								</label>
+								<input
+									id="new-tag-name"
+									type="text"
+									value={newName}
+									onChange={(e) => setNewName(e.target.value)}
+									placeholder="例: 極ナイツ・オブ・ラウンド"
+									className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
+								/>
+								{createErrors.name && (
+									<p className="mt-1 text-xs text-destructive">{createErrors.name.join(', ')}</p>
+								)}
+							</div>
+							<div>
+								<label
+									htmlFor="new-tag-category"
+									className="block text-sm font-medium text-foreground mb-1"
+								>
+									カテゴリ
+								</label>
+								<select
+									id="new-tag-category"
+									value={newCategory}
+									onChange={(e) => setNewCategory(e.target.value as TagCategory)}
+									className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+								>
+									{CATEGORIES.map((cat) => (
+										<option key={cat} value={cat}>
+											{CATEGORY_LABELS[cat]}
+										</option>
+									))}
+								</select>
+								{createErrors.category && (
+									<p className="mt-1 text-xs text-destructive">
+										{createErrors.category.join(', ')}
+									</p>
+								)}
+							</div>
+							<button
+								type="button"
+								onClick={handleCreate}
+								disabled={isCreating || !newName.trim()}
+								className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+							>
+								{isCreating ? '作成中...' : '作成'}
+							</button>
+						</div>
+					</div>
+				)}
+
+				{/* 削除確認ダイアログ */}
+				{deletingId && (
+					<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+						<div className="rounded-lg border border-border bg-card p-6 shadow-lg max-w-sm mx-4">
+							<h3 className="text-lg font-bold text-foreground mb-2">タグを削除</h3>
+							<p className="text-sm text-muted-foreground mb-4">
+								このタグを削除しますか？関連する記事からもタグが外れます。この操作は取り消せません。
+							</p>
+							<div className="flex gap-2 justify-end">
+								<button
+									type="button"
+									onClick={() => setDeletingId(null)}
+									disabled={isDeleting}
+									className="rounded-md border border-border px-3 py-1.5 text-sm text-foreground hover:bg-muted transition-colors"
+								>
+									キャンセル
+								</button>
+								<button
+									type="button"
+									onClick={() => handleDelete(deletingId)}
+									disabled={isDeleting}
+									className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+								>
+									{isDeleting ? '削除中...' : '削除'}
+								</button>
+							</div>
+						</div>
+					</div>
+				)}
+
+				{/* タグ一覧 (カテゴリ別) */}
+				<div className="divide-y divide-border">
+					{tags.length === 0 ? (
+						<div className="p-8 text-center text-sm text-muted-foreground">
+							タグがまだ登録されていません
+						</div>
+					) : (
+						CATEGORIES.map((category) => {
+							const categoryTags = grouped.get(category);
+							if (!categoryTags || categoryTags.length === 0) return null;
+
+							return (
+								<div key={category} className="p-4">
+									<h3 className="text-sm font-medium text-muted-foreground mb-3">
+										{CATEGORY_LABELS[category]} ({categoryTags.length})
+									</h3>
+									<div className="space-y-2">
+										{categoryTags.map((tag) => (
+											<div key={tag.id}>
+												{editingId === tag.id ? (
+													// 編集フォーム
+													<div className="rounded-md border border-primary/30 bg-primary/5 p-3 space-y-3">
+														{editErrors._ && (
+															<p className="text-sm text-destructive">{editErrors._.join(', ')}</p>
+														)}
+														<div className="flex flex-col sm:flex-row gap-2">
+															<div className="flex-1">
+																<input
+																	type="text"
+																	value={editName}
+																	onChange={(e) => setEditName(e.target.value)}
+																	className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground"
+																/>
+																{editErrors.name && (
+																	<p className="mt-1 text-xs text-destructive">
+																		{editErrors.name.join(', ')}
+																	</p>
+																)}
+															</div>
+															<select
+																value={editCategory}
+																onChange={(e) => setEditCategory(e.target.value as TagCategory)}
+																className="rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+															>
+																{CATEGORIES.map((cat) => (
+																	<option key={cat} value={cat}>
+																		{CATEGORY_LABELS[cat]}
+																	</option>
+																))}
+															</select>
+														</div>
+														{editErrors.category && (
+															<p className="text-xs text-destructive">
+																{editErrors.category.join(', ')}
+															</p>
+														)}
+														<div className="flex gap-2">
+															<button
+																type="button"
+																onClick={handleUpdate}
+																disabled={isUpdating || !editName.trim()}
+																className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+															>
+																{isUpdating ? '更新中...' : '保存'}
+															</button>
+															<button
+																type="button"
+																onClick={cancelEdit}
+																disabled={isUpdating}
+																className="rounded-md border border-border px-3 py-1 text-xs text-foreground hover:bg-muted transition-colors"
+															>
+																キャンセル
+															</button>
+														</div>
+													</div>
+												) : (
+													// 表示モード
+													<div className="flex items-center justify-between rounded-md px-3 py-2 hover:bg-muted/50 transition-colors group">
+														<div className="flex items-center gap-2">
+															<span className="text-sm text-foreground">{tag.name}</span>
+															<span className="text-xs text-muted-foreground">({tag.slug})</span>
+														</div>
+														<div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+															<button
+																type="button"
+																onClick={() => startEdit(tag)}
+																className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+															>
+																編集
+															</button>
+															<button
+																type="button"
+																onClick={() => setDeletingId(tag.id)}
+																className="rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+															>
+																削除
+															</button>
+														</div>
+													</div>
+												)}
+											</div>
+										))}
+									</div>
+								</div>
+							);
+						})
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -50,3 +50,80 @@ export function groupTagsByCategory(tagList: TagInfo[]): GroupedTags {
 	}
 	return grouped;
 }
+
+export function generateTagSlug(name: string): string {
+	return name
+		.toLowerCase()
+		.trim()
+		.replace(/[\s　]+/g, '-')
+		.replace(/[^a-z0-9\u3000-\u9fff\uf900-\ufaff-]/g, '')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+export interface CreateTagData {
+	name: string;
+	slug: string;
+	category: TagCategory;
+}
+
+export async function createTag(db: Database, data: CreateTagData): Promise<TagInfo> {
+	const [row] = await db
+		.insert(tags)
+		.values({
+			name: data.name,
+			slug: data.slug,
+			category: data.category,
+		})
+		.returning({
+			id: tags.id,
+			name: tags.name,
+			slug: tags.slug,
+			category: tags.category,
+		});
+	return row;
+}
+
+export interface UpdateTagData {
+	name?: string;
+	slug?: string;
+	category?: TagCategory;
+}
+
+export async function updateTag(
+	db: Database,
+	id: string,
+	data: UpdateTagData,
+): Promise<TagInfo | null> {
+	const updates: Record<string, unknown> = {};
+	if (data.name !== undefined) updates.name = data.name;
+	if (data.slug !== undefined) updates.slug = data.slug;
+	if (data.category !== undefined) updates.category = data.category;
+
+	const [row] = await db.update(tags).set(updates).where(eq(tags.id, id)).returning({
+		id: tags.id,
+		name: tags.name,
+		slug: tags.slug,
+		category: tags.category,
+	});
+	return row ?? null;
+}
+
+export async function deleteTag(db: Database, id: string): Promise<boolean> {
+	const result = await db.delete(tags).where(eq(tags.id, id)).returning({ id: tags.id });
+	return result.length > 0;
+}
+
+export async function getTagById(db: Database, id: string): Promise<TagInfo | null> {
+	const [row] = await db
+		.select({
+			id: tags.id,
+			name: tags.name,
+			slug: tags.slug,
+			category: tags.category,
+		})
+		.from(tags)
+		.where(eq(tags.id, id))
+		.limit(1);
+	return row ?? null;
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -251,6 +251,106 @@ export function validateCreateReport(data: unknown): ValidationResult<CreateRepo
 	};
 }
 
+// Tag validation
+const TAG_CATEGORIES_VALID = ['duty', 'job', 'crafting', 'gathering', 'general'] as const;
+type TagCategoryValid = (typeof TAG_CATEGORIES_VALID)[number];
+
+export interface CreateTagInput {
+	name: string;
+	category: TagCategoryValid;
+}
+
+export interface UpdateTagInput {
+	name?: string;
+	category?: TagCategoryValid;
+}
+
+export function validateCreateTag(data: unknown): ValidationResult<CreateTagInput> {
+	if (typeof data !== 'object' || data === null) {
+		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
+	}
+
+	const obj = data as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	// name
+	if (obj.name === undefined || obj.name === null) {
+		errors.name = ['name is required'];
+	} else if (typeof obj.name !== 'string') {
+		errors.name = ['name must be a string'];
+	} else if (obj.name.trim().length < 1 || obj.name.trim().length > 50) {
+		errors.name = ['name must be between 1 and 50 characters'];
+	}
+
+	// category
+	if (obj.category === undefined || obj.category === null) {
+		errors.category = ['category is required'];
+	} else if (typeof obj.category !== 'string') {
+		errors.category = ['category must be a string'];
+	} else if (!(TAG_CATEGORIES_VALID as readonly string[]).includes(obj.category)) {
+		errors.category = [`category must be one of: ${TAG_CATEGORIES_VALID.join(', ')}`];
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { success: false, errors };
+	}
+
+	return {
+		success: true,
+		data: {
+			name: (obj.name as string).trim(),
+			category: obj.category as TagCategoryValid,
+		},
+	};
+}
+
+export function validateUpdateTag(data: unknown): ValidationResult<UpdateTagInput> {
+	if (typeof data !== 'object' || data === null) {
+		return { success: false, errors: { _: ['Request body must be a JSON object'] } };
+	}
+
+	const obj = data as Record<string, unknown>;
+	const errors: Record<string, string[]> = {};
+
+	const hasName = obj.name !== undefined;
+	const hasCategory = obj.category !== undefined;
+
+	if (!hasName && !hasCategory) {
+		return {
+			success: false,
+			errors: { _: ['At least one field must be provided'] },
+		};
+	}
+
+	// name (optional)
+	if (hasName) {
+		if (typeof obj.name !== 'string') {
+			errors.name = ['name must be a string'];
+		} else if (obj.name.trim().length < 1 || obj.name.trim().length > 50) {
+			errors.name = ['name must be between 1 and 50 characters'];
+		}
+	}
+
+	// category (optional)
+	if (hasCategory) {
+		if (typeof obj.category !== 'string') {
+			errors.category = ['category must be a string'];
+		} else if (!(TAG_CATEGORIES_VALID as readonly string[]).includes(obj.category)) {
+			errors.category = [`category must be one of: ${TAG_CATEGORIES_VALID.join(', ')}`];
+		}
+	}
+
+	if (Object.keys(errors).length > 0) {
+		return { success: false, errors };
+	}
+
+	const result: UpdateTagInput = {};
+	if (hasName) result.name = (obj.name as string).trim();
+	if (hasCategory) result.category = obj.category as TagCategoryValid;
+
+	return { success: true, data: result };
+}
+
 const REPORT_STATUSES = ['resolved', 'dismissed'] as const;
 
 export function validateUpdateReport(data: unknown): ValidationResult<UpdateReportInput> {

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,4 +1,5 @@
 ---
+import TagManagement from '../../components/admin/TagManagement.tsx';
 import UserManagement from '../../components/admin/UserManagement.tsx';
 import Layout from '../../layouts/Layout.astro';
 
@@ -11,8 +12,9 @@ if (!currentUser || currentUser.profile?.role !== 'admin') {
 ---
 
 <Layout title="管理画面">
-	<div class="py-8 max-w-4xl mx-auto">
-		<h1 class="text-3xl font-bold text-foreground mb-8">管理画面</h1>
+	<div class="py-8 max-w-4xl mx-auto space-y-8">
+		<h1 class="text-3xl font-bold text-foreground">管理画面</h1>
+		<TagManagement client:load />
 		<UserManagement client:load currentUserId={currentUser.id} />
 	</div>
 </Layout>

--- a/src/pages/api/admin/tags/[id].ts
+++ b/src/pages/api/admin/tags/[id].ts
@@ -1,0 +1,83 @@
+import type { APIContext } from 'astro';
+import { forbidden, notFound, unauthorized, validationError } from '../../../../lib/errors';
+import { deleteTag, generateTagSlug, getTagById, updateTag } from '../../../../lib/tags';
+import { validateUpdateTag } from '../../../../lib/validation';
+
+export async function PATCH(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const tagId = context.params.id as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	const existing = await getTagById(db, tagId);
+	if (!existing) {
+		return notFound('Tag not found');
+	}
+
+	let body: unknown;
+	try {
+		body = await context.request.json();
+	} catch {
+		return validationError({ _: ['Request body must be valid JSON'] });
+	}
+
+	const result = validateUpdateTag(body);
+	if (!result.success) {
+		return validationError(result.errors);
+	}
+
+	const updates: Parameters<typeof updateTag>[2] = {};
+	if (result.data.name !== undefined) {
+		updates.name = result.data.name;
+		updates.slug = generateTagSlug(result.data.name);
+		if (!updates.slug) {
+			return validationError({ name: ['タグ名からスラグを生成できません'] });
+		}
+	}
+	if (result.data.category !== undefined) {
+		updates.category = result.data.category;
+	}
+
+	try {
+		const tag = await updateTag(db, tagId, updates);
+		if (!tag) {
+			return notFound('Tag not found');
+		}
+
+		return new Response(JSON.stringify({ tag }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('unique')) {
+			return validationError({ name: ['同じ名前またはスラグのタグが既に存在します'] });
+		}
+		throw err;
+	}
+}
+
+export async function DELETE(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+	const tagId = context.params.id as string;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	const deleted = await deleteTag(db, tagId);
+	if (!deleted) {
+		return notFound('Tag not found');
+	}
+
+	return new Response(null, { status: 204 });
+}

--- a/src/pages/api/admin/tags/index.ts
+++ b/src/pages/api/admin/tags/index.ts
@@ -1,0 +1,70 @@
+import type { APIContext } from 'astro';
+import { forbidden, unauthorized, validationError } from '../../../../lib/errors';
+import { createTag, generateTagSlug, listTags } from '../../../../lib/tags';
+import { validateCreateTag } from '../../../../lib/validation';
+
+export async function GET(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	const tagList = await listTags(db);
+
+	return new Response(JSON.stringify({ tags: tagList }), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+export async function POST(context: APIContext): Promise<Response> {
+	const { db, currentUser } = context.locals;
+
+	if (!currentUser) {
+		return unauthorized();
+	}
+
+	if (currentUser.profile?.role !== 'admin') {
+		return forbidden();
+	}
+
+	let body: unknown;
+	try {
+		body = await context.request.json();
+	} catch {
+		return validationError({ _: ['Request body must be valid JSON'] });
+	}
+
+	const result = validateCreateTag(body);
+	if (!result.success) {
+		return validationError(result.errors);
+	}
+
+	const slug = generateTagSlug(result.data.name);
+	if (!slug) {
+		return validationError({ name: ['タグ名からスラグを生成できません'] });
+	}
+
+	try {
+		const tag = await createTag(db, {
+			name: result.data.name,
+			slug,
+			category: result.data.category,
+		});
+
+		return new Response(JSON.stringify({ tag }), {
+			status: 201,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('unique')) {
+			return validationError({ name: ['同じ名前またはスラグのタグが既に存在します'] });
+		}
+		throw err;
+	}
+}


### PR DESCRIPTION
## Summary
- admin向けのタグ管理画面を実装
- タグの追加・編集・削除が可能なUI（カテゴリ別表示）
- admin専用API（POST/PATCH/DELETE /api/admin/tags）
- バリデーション、エラーハンドリング、削除確認ダイアログを含む

Closes #66

## Test plan
- [ ] adminユーザーでログインし、管理画面にタグ管理セクションが表示されることを確認
- [ ] 「新規追加」からタグを作成できることを確認（各カテゴリ）
- [ ] 既存タグの一覧がカテゴリ別に表示されることを確認
- [ ] タグの編集（名前・カテゴリ変更）ができることを確認
- [ ] タグの削除ができることを確認（確認ダイアログあり）
- [ ] admin以外のユーザーでアクセスすると管理画面にリダイレクトされることを確認
- [ ] admin以外のユーザーでAPIを直接叩くと403が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)