### PR TITLE
feat: タグ管理UIでslugを編集可能にする (#72)

### DIFF
--- a/src/components/admin/TagManagement.tsx
+++ b/src/components/admin/TagManagement.tsx
@@ -28,6 +28,7 @@ export default function TagManagement() {
 	// 新規作成フォーム
 	const [showCreateForm, setShowCreateForm] = useState(false);
 	const [newName, setNewName] = useState('');
+	const [newSlug, setNewSlug] = useState('');
 	const [newCategory, setNewCategory] = useState<TagCategory>('general');
 	const [isCreating, setIsCreating] = useState(false);
 	const [createErrors, setCreateErrors] = useState<Record<string, string[]>>({});
@@ -35,6 +36,7 @@ export default function TagManagement() {
 	// 編集状態
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editName, setEditName] = useState('');
+	const [editSlug, setEditSlug] = useState('');
 	const [editCategory, setEditCategory] = useState<TagCategory>('general');
 	const [isUpdating, setIsUpdating] = useState(false);
 	const [editErrors, setEditErrors] = useState<Record<string, string[]>>({});
@@ -77,10 +79,12 @@ export default function TagManagement() {
 		setCreateErrors({});
 
 		try {
+			const payload: Record<string, string> = { name: newName, category: newCategory };
+			if (newSlug.trim()) payload.slug = newSlug.trim();
 			const res = await fetch('/api/admin/tags', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ name: newName, category: newCategory }),
+				body: JSON.stringify(payload),
 			});
 
 			if (!res.ok) {
@@ -96,6 +100,7 @@ export default function TagManagement() {
 			const json = await res.json();
 			setTags((prev) => [...prev, json.tag].sort((a, b) => a.name.localeCompare(b.name)));
 			setNewName('');
+			setNewSlug('');
 			setNewCategory('general');
 			setShowCreateForm(false);
 			setToast({ message: 'タグを作成しました', type: 'success' });
@@ -109,6 +114,7 @@ export default function TagManagement() {
 	function startEdit(tag: Tag) {
 		setEditingId(tag.id);
 		setEditName(tag.name);
+		setEditSlug(tag.slug);
 		setEditCategory(tag.category as TagCategory);
 		setEditErrors({});
 	}
@@ -127,7 +133,7 @@ export default function TagManagement() {
 			const res = await fetch(`/api/admin/tags/${editingId}`, {
 				method: 'PATCH',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ name: editName, category: editCategory }),
+				body: JSON.stringify({ name: editName, slug: editSlug, category: editCategory }),
 			});
 
 			if (!res.ok) {
@@ -259,6 +265,28 @@ export default function TagManagement() {
 							</div>
 							<div>
 								<label
+									htmlFor="new-tag-slug"
+									className="block text-sm font-medium text-foreground mb-1"
+								>
+									スラグ
+									<span className="ml-1 text-xs font-normal text-muted-foreground">
+										(空欄で自動生成)
+									</span>
+								</label>
+								<input
+									id="new-tag-slug"
+									type="text"
+									value={newSlug}
+									onChange={(e) => setNewSlug(e.target.value)}
+									placeholder="例: knights-of-the-round-extreme"
+									className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
+								/>
+								{createErrors.slug && (
+									<p className="mt-1 text-xs text-destructive">{createErrors.slug.join(', ')}</p>
+								)}
+							</div>
+							<div>
+								<label
 									htmlFor="new-tag-category"
 									className="block text-sm font-medium text-foreground mb-1"
 								>
@@ -351,7 +379,14 @@ export default function TagManagement() {
 														)}
 														<div className="flex flex-col sm:flex-row gap-2">
 															<div className="flex-1">
+																<label
+																	htmlFor={`edit-tag-name-${tag.id}`}
+																	className="block text-xs text-muted-foreground mb-1"
+																>
+																	タグ名
+																</label>
 																<input
+																	id={`edit-tag-name-${tag.id}`}
 																	type="text"
 																	value={editName}
 																	onChange={(e) => setEditName(e.target.value)}
@@ -366,7 +401,7 @@ export default function TagManagement() {
 															<select
 																value={editCategory}
 																onChange={(e) => setEditCategory(e.target.value as TagCategory)}
-																className="rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+																className="rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground self-end"
 															>
 																{CATEGORIES.map((cat) => (
 																	<option key={cat} value={cat}>
@@ -374,6 +409,26 @@ export default function TagManagement() {
 																	</option>
 																))}
 															</select>
+														</div>
+														<div>
+															<label
+																htmlFor={`edit-tag-slug-${tag.id}`}
+																className="block text-xs text-muted-foreground mb-1"
+															>
+																スラグ
+															</label>
+															<input
+																id={`edit-tag-slug-${tag.id}`}
+																type="text"
+																value={editSlug}
+																onChange={(e) => setEditSlug(e.target.value)}
+																className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground"
+															/>
+															{editErrors.slug && (
+																<p className="mt-1 text-xs text-destructive">
+																	{editErrors.slug.join(', ')}
+																</p>
+															)}
 														</div>
 														{editErrors.category && (
 															<p className="text-xs text-destructive">

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -255,13 +255,18 @@ export function validateCreateReport(data: unknown): ValidationResult<CreateRepo
 const TAG_CATEGORIES_VALID = ['duty', 'job', 'crafting', 'gathering', 'general'] as const;
 type TagCategoryValid = (typeof TAG_CATEGORIES_VALID)[number];
 
+const SLUG_REGEX =
+	/^[a-z0-9\u3000-\u9fff\uf900-\ufaff]([a-z0-9\u3000-\u9fff\uf900-\ufaff-]*[a-z0-9\u3000-\u9fff\uf900-\ufaff])?$/;
+
 export interface CreateTagInput {
 	name: string;
+	slug?: string;
 	category: TagCategoryValid;
 }
 
 export interface UpdateTagInput {
 	name?: string;
+	slug?: string;
 	category?: TagCategoryValid;
 }
 
@@ -282,6 +287,17 @@ export function validateCreateTag(data: unknown): ValidationResult<CreateTagInpu
 		errors.name = ['name must be between 1 and 50 characters'];
 	}
 
+	// slug (optional)
+	if (obj.slug !== undefined && obj.slug !== null && obj.slug !== '') {
+		if (typeof obj.slug !== 'string') {
+			errors.slug = ['slug must be a string'];
+		} else if (obj.slug.length > 100) {
+			errors.slug = ['slug must be at most 100 characters'];
+		} else if (!SLUG_REGEX.test(obj.slug)) {
+			errors.slug = ['slugは小文字英数字・ハイフン・日本語のみ使用できます'];
+		}
+	}
+
 	// category
 	if (obj.category === undefined || obj.category === null) {
 		errors.category = ['category is required'];
@@ -295,13 +311,15 @@ export function validateCreateTag(data: unknown): ValidationResult<CreateTagInpu
 		return { success: false, errors };
 	}
 
-	return {
-		success: true,
-		data: {
-			name: (obj.name as string).trim(),
-			category: obj.category as TagCategoryValid,
-		},
+	const result: CreateTagInput = {
+		name: (obj.name as string).trim(),
+		category: obj.category as TagCategoryValid,
 	};
+	if (typeof obj.slug === 'string' && obj.slug.trim() !== '') {
+		result.slug = obj.slug.trim();
+	}
+
+	return { success: true, data: result };
 }
 
 export function validateUpdateTag(data: unknown): ValidationResult<UpdateTagInput> {
@@ -313,9 +331,10 @@ export function validateUpdateTag(data: unknown): ValidationResult<UpdateTagInpu
 	const errors: Record<string, string[]> = {};
 
 	const hasName = obj.name !== undefined;
+	const hasSlug = obj.slug !== undefined;
 	const hasCategory = obj.category !== undefined;
 
-	if (!hasName && !hasCategory) {
+	if (!hasName && !hasSlug && !hasCategory) {
 		return {
 			success: false,
 			errors: { _: ['At least one field must be provided'] },
@@ -328,6 +347,19 @@ export function validateUpdateTag(data: unknown): ValidationResult<UpdateTagInpu
 			errors.name = ['name must be a string'];
 		} else if (obj.name.trim().length < 1 || obj.name.trim().length > 50) {
 			errors.name = ['name must be between 1 and 50 characters'];
+		}
+	}
+
+	// slug (optional)
+	if (hasSlug) {
+		if (typeof obj.slug !== 'string') {
+			errors.slug = ['slug must be a string'];
+		} else if (obj.slug.trim() === '') {
+			errors.slug = ['slug must not be empty'];
+		} else if (obj.slug.length > 100) {
+			errors.slug = ['slug must be at most 100 characters'];
+		} else if (!SLUG_REGEX.test(obj.slug)) {
+			errors.slug = ['slugは小文字英数字・ハイフン・日本語のみ使用できます'];
 		}
 	}
 
@@ -346,6 +378,7 @@ export function validateUpdateTag(data: unknown): ValidationResult<UpdateTagInpu
 
 	const result: UpdateTagInput = {};
 	if (hasName) result.name = (obj.name as string).trim();
+	if (hasSlug) result.slug = (obj.slug as string).trim();
 	if (hasCategory) result.category = obj.category as TagCategoryValid;
 
 	return { success: true, data: result };

--- a/src/pages/api/admin/tags/[id].ts
+++ b/src/pages/api/admin/tags/[id].ts
@@ -35,9 +35,13 @@ export async function PATCH(context: APIContext): Promise<Response> {
 	const updates: Parameters<typeof updateTag>[2] = {};
 	if (result.data.name !== undefined) {
 		updates.name = result.data.name;
+	}
+	if (result.data.slug !== undefined) {
+		updates.slug = result.data.slug;
+	} else if (result.data.name !== undefined) {
 		updates.slug = generateTagSlug(result.data.name);
 		if (!updates.slug) {
-			return validationError({ name: ['タグ名からスラグを生成できません'] });
+			return validationError({ slug: ['スラグを生成できません。手動で指定してください'] });
 		}
 	}
 	if (result.data.category !== undefined) {

--- a/src/pages/api/admin/tags/index.ts
+++ b/src/pages/api/admin/tags/index.ts
@@ -45,9 +45,9 @@ export async function POST(context: APIContext): Promise<Response> {
 		return validationError(result.errors);
 	}
 
-	const slug = generateTagSlug(result.data.name);
+	const slug = result.data.slug ?? generateTagSlug(result.data.name);
 	if (!slug) {
-		return validationError({ name: ['タグ名からスラグを生成できません'] });
+		return validationError({ slug: ['スラグを生成できません。手動で指定してください'] });
 	}
 
 	try {


### PR DESCRIPTION
## Summary
- タグ作成時にslugを手動指定可能にした（空欄の場合はタグ名から自動生成）
- タグ編集時にslugの変更を可能にした
- slug専用のバリデーション追加（小文字英数字・ハイフン・日本語のみ許可）

Closes #72

## Test plan
- [ ] タグ作成時にslugを空欄にすると自動生成されることを確認
- [ ] タグ作成時にslugを手動指定できることを確認
- [ ] タグ編集時にslugを変更できることを確認
- [ ] 不正なslug（大文字・特殊文字等）でバリデーションエラーが出ることを確認
- [ ] 重複するslugでエラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)