### PR TITLE
fix: トップページ・タグ一覧のカテゴリをDB動的取得に変更

### DIFF
--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -4,9 +4,6 @@ import { tags } from '../db/schema';
 
 export type TagCategory = string;
 
-/** @deprecated Use listCategories() from categories.ts instead */
-export const TAG_CATEGORIES = ['duty', 'job', 'crafting', 'gathering', 'general'] as const;
-
 export interface TagInfo {
 	id: string;
 	name: string;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,30 +2,21 @@
 import ArticleCard from '../components/ArticleCard.astro';
 import Layout from '../layouts/Layout.astro';
 import { listArticles } from '../lib/articles';
-import { groupTagsByCategory, listTags, TAG_CATEGORIES } from '../lib/tags';
-
-const categoryLabels: Record<string, string> = {
-	duty: 'コンテンツ',
-	job: 'ジョブ',
-	crafting: 'クラフター',
-	gathering: 'ギャザラー',
-	general: 'その他',
-};
+import { listCategories } from '../lib/categories';
+import { groupTagsByCategory, listTags } from '../lib/tags';
 
 const listOpts = { skipCount: true, excludeBody: true, status: 'published' as const };
-const { data: popularArticles } = await listArticles(Astro.locals.db, {
-	...listOpts,
-	limit: 6,
-	sort: 'popular',
-});
-const { data: newestArticles } = await listArticles(Astro.locals.db, {
-	...listOpts,
-	limit: 6,
-	sort: 'newest',
-});
-const allTags = await listTags(Astro.locals.db);
+const [{ data: popularArticles }, { data: newestArticles }, allTags, categories] =
+	await Promise.all([
+		listArticles(Astro.locals.db, { ...listOpts, limit: 6, sort: 'popular' }),
+		listArticles(Astro.locals.db, { ...listOpts, limit: 6, sort: 'newest' }),
+		listTags(Astro.locals.db),
+		listCategories(Astro.locals.db),
+	]);
 
 const groupedTags = groupTagsByCategory(allTags);
+const categoryLabels = new Map(categories.map((c) => [c.slug, c.name]));
+const categorySlugs = categories.map((c) => c.slug);
 ---
 
 <Layout title="トップ" description="XIVPedia - ユーザー投稿型のFF14攻略サイト">
@@ -91,13 +82,13 @@ const groupedTags = groupTagsByCategory(allTags);
 		<h2 class="text-2xl font-bold text-foreground mb-6">🏷️ カテゴリ</h2>
 
 		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-			{TAG_CATEGORIES.map((category) => {
+			{categorySlugs.map((category) => {
 				const tagsInCategory = groupedTags[category] ?? [];
 				if (tagsInCategory.length === 0) return null;
 				return (
 					<div class="bg-card rounded-lg border border-border p-6">
 						<h3 class="text-lg font-bold text-foreground mb-4">
-							{categoryLabels[category] ?? category}
+							{categoryLabels.get(category) ?? category}
 						</h3>
 						<div class="flex flex-wrap gap-2">
 							{tagsInCategory.map((tag) => (

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -3,30 +3,27 @@ import { count, eq } from 'drizzle-orm';
 import TagList from '../../components/TagList.astro';
 import { articles, articleTags } from '../../db/schema';
 import Layout from '../../layouts/Layout.astro';
-import { groupTagsByCategory, listTags, TAG_CATEGORIES } from '../../lib/tags';
+import { listCategories } from '../../lib/categories';
+import { groupTagsByCategory, listTags } from '../../lib/tags';
 
-const allTags = await listTags(Astro.locals.db);
+const [allTags, categories, tagCounts] = await Promise.all([
+	listTags(Astro.locals.db),
+	listCategories(Astro.locals.db),
+	Astro.locals.db
+		.select({
+			tagId: articleTags.tagId,
+			count: count(),
+		})
+		.from(articleTags)
+		.innerJoin(articles, eq(articleTags.articleId, articles.id))
+		.where(eq(articles.status, 'published'))
+		.groupBy(articleTags.tagId),
+]);
+
 const grouped = groupTagsByCategory(allTags);
-
-const tagCounts = await Astro.locals.db
-	.select({
-		tagId: articleTags.tagId,
-		count: count(),
-	})
-	.from(articleTags)
-	.innerJoin(articles, eq(articleTags.articleId, articles.id))
-	.where(eq(articles.status, 'published'))
-	.groupBy(articleTags.tagId);
-
 const countMap = new Map(tagCounts.map((r) => [r.tagId, r.count]));
-
-const categoryNames: Record<string, string> = {
-	duty: 'コンテンツ',
-	job: 'ジョブ',
-	crafting: 'クラフター',
-	gathering: 'ギャザラー',
-	general: 'その他',
-};
+const categoryNames = new Map(categories.map((c) => [c.slug, c.name]));
+const categorySlugs = categories.map((c) => c.slug);
 ---
 
 <Layout title="タグ一覧" description="XIVPedia - タグ一覧">
@@ -34,7 +31,7 @@ const categoryNames: Record<string, string> = {
 		<h1 class="text-3xl font-bold text-foreground">タグ一覧</h1>
 
 		<div class="mt-8 space-y-10">
-			{TAG_CATEGORIES.map((category) => {
+			{categorySlugs.map((category) => {
 				const tagsInCategory = grouped[category];
 				if (!tagsInCategory || tagsInCategory.length === 0) return null;
 
@@ -46,7 +43,7 @@ const categoryNames: Record<string, string> = {
 				return (
 					<section>
 						<h2 class="text-2xl font-bold text-foreground mb-6">
-							{categoryNames[category]}
+							{categoryNames.get(category) ?? category}
 						</h2>
 						<TagList tags={tagsWithCount} />
 					</section>


### PR DESCRIPTION
## Summary
- トップページ (`index.astro`) とタグ一覧ページ (`tags/index.astro`) でハードコードされた `TAG_CATEGORIES` 定数と `categoryLabels` / `categoryNames` を削除
- `tag_categories` テーブルから `listCategories()` で動的に取得するよう変更
- クエリを `Promise.all` で並列化しパフォーマンス改善
- 未使用となった `TAG_CATEGORIES` 定数を `lib/tags.ts` から削除

## 背景
PR #75 でカテゴリ管理機能を追加したが、公開ページ（トップ・タグ一覧）のカテゴリ表示がハードコードのままだったため、管理画面でカテゴリを追加・変更しても公開ページに反映されなかった。

## Test plan
- [ ] トップページのカテゴリセクションが `tag_categories` テーブルのデータで表示されること
- [ ] タグ一覧ページのカテゴリ見出しが動的に取得されること
- [ ] 管理画面でカテゴリを追加した場合、再デプロイなしで公開ページに反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)