### PR TITLE
feat: 記事エディタにFF14マクロブロック挿入機能を追加 (#80)

### DIFF
--- a/src/components/ArticleContent.astro
+++ b/src/components/ArticleContent.astro
@@ -203,4 +203,117 @@ const { html, articleId, isLoggedIn = false } = Astro.props;
 	.article-content :global(em) {
 		font-style: italic;
 	}
+
+	/* FF14 Macro Block */
+	.article-content :global(.ffxiv-macro-block) {
+		margin-top: 1.25rem;
+		margin-bottom: 1.25rem;
+		border-radius: 0.5rem;
+		border: 1px solid var(--color-border);
+		overflow: hidden;
+		background-color: #1a1a2e;
+	}
+
+	.article-content :global(.ffxiv-macro-header) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.5rem 0.75rem;
+		background-color: #16213e;
+		border-bottom: 1px solid #0f3460;
+	}
+
+	.article-content :global(.ffxiv-macro-label) {
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: #e0c080;
+		letter-spacing: 0.05em;
+	}
+
+	.article-content :global(.ffxiv-macro-copy) {
+		font-size: 0.75rem;
+		padding: 0.25rem 0.625rem;
+		border-radius: 0.25rem;
+		border: 1px solid #0f3460;
+		background-color: #0f3460;
+		color: #a0b4d0;
+		cursor: pointer;
+		transition: background-color 0.15s, color 0.15s;
+	}
+
+	.article-content :global(.ffxiv-macro-copy:hover) {
+		background-color: #1a4080;
+		color: #e0e0e0;
+	}
+
+	.article-content :global(.ffxiv-macro-copy[data-copied="true"]) {
+		background-color: #2d5016;
+		border-color: #3d6b20;
+		color: #90d060;
+	}
+
+	.article-content :global(.ffxiv-macro-code) {
+		margin: 0 !important;
+		padding: 0.75rem 1rem !important;
+		background-color: #1a1a2e !important;
+		border: none !important;
+		border-radius: 0 !important;
+		font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+		font-size: 0.8125rem !important;
+		line-height: 1.7 !important;
+		overflow-x: auto;
+	}
+
+	.article-content :global(.ffxiv-macro-code code) {
+		background-color: transparent !important;
+		padding: 0 !important;
+		font-size: inherit !important;
+	}
+
+	.article-content :global(.ffxiv-macro-footer) {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		padding: 0.375rem 0.75rem;
+		background-color: #16213e;
+		border-top: 1px solid #0f3460;
+	}
+
+	.article-content :global(.ffxiv-macro-line-count) {
+		font-size: 0.6875rem;
+		color: #6080a0;
+	}
+
+	.article-content :global(.macro-command) {
+		color: #7cacf8;
+		font-weight: 600;
+	}
+
+	.article-content :global(.macro-placeholder) {
+		color: #f0a050;
+	}
+
+	.article-content :global(.macro-text) {
+		color: #c8d0d8;
+	}
 </style>
+
+<script>
+	document.addEventListener('click', (e) => {
+		const target = e.target as HTMLElement;
+		if (!target.classList.contains('ffxiv-macro-copy')) return;
+
+		const macroText = target.getAttribute('data-macro-text');
+		if (!macroText) return;
+
+		navigator.clipboard.writeText(macroText).then(() => {
+			const originalText = target.textContent;
+			target.textContent = 'コピー済み';
+			target.setAttribute('data-copied', 'true');
+			setTimeout(() => {
+				target.textContent = originalText;
+				target.removeAttribute('data-copied');
+			}, 2000);
+		});
+	});
+</script>

--- a/src/components/editor/ArticleEditor.tsx
+++ b/src/components/editor/ArticleEditor.tsx
@@ -1,4 +1,4 @@
-import { Eye, Pen, Save, Send } from 'lucide-react';
+import { Eye, Gamepad2, Pen, Save, Send } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -41,8 +41,32 @@ export function ArticleEditor({ mode, tags, article }: ArticleEditorProps) {
 	const [editorMode, setEditorMode] = useState<EditorMode>('visual');
 	const [richEditorKey, setRichEditorKey] = useState(0);
 
+	const [showMacroDialogMd, setShowMacroDialogMd] = useState(false);
+	const [macroTextMd, setMacroTextMd] = useState('');
+
+	const macroLineCountMd = macroTextMd ? macroTextMd.split('\n').length : 0;
+
 	const handleImageInsert = useCallback((markdown: string) => {
 		setBody((prev) => `${prev}\n${markdown}\n`);
+	}, []);
+
+	const handleInsertMacro = useCallback((macro: string) => {
+		const macroBlock = `\n\n\`\`\`ffxiv-macro\n${macro}\n\`\`\`\n`;
+		setBody((prev) => prev + macroBlock);
+		setRichEditorKey((prev) => prev + 1);
+	}, []);
+
+	const insertMacroMd = useCallback(() => {
+		if (macroTextMd.trim()) {
+			handleInsertMacro(macroTextMd.trim());
+		}
+		setMacroTextMd('');
+		setShowMacroDialogMd(false);
+	}, [macroTextMd, handleInsertMacro]);
+
+	const cancelMacroMd = useCallback(() => {
+		setMacroTextMd('');
+		setShowMacroDialogMd(false);
 	}, []);
 
 	const handleEditorModeChange = useCallback(
@@ -191,7 +215,12 @@ export function ArticleEditor({ mode, tags, article }: ArticleEditorProps) {
 
 				{editorMode === 'visual' ? (
 					<>
-						<RichTextEditor key={richEditorKey} content={body} onChange={setBody} />
+						<RichTextEditor
+							key={richEditorKey}
+							content={body}
+							onChange={setBody}
+							onInsertMacro={handleInsertMacro}
+						/>
 						{errors.body && <p className="text-sm text-destructive mt-1">{errors.body[0]}</p>}
 						<p className="text-xs text-muted-foreground text-right mt-1">
 							{body.length.toLocaleString()}/50,000
@@ -256,8 +285,60 @@ export function ArticleEditor({ mode, tags, article }: ArticleEditorProps) {
 				)}
 			</div>
 
-			{/* Image uploader (Markdown mode only) */}
-			{editorMode === 'markdown' && <ImageUploader onInsert={handleImageInsert} />}
+			{/* Image uploader & Macro insert (Markdown mode only) */}
+			{editorMode === 'markdown' && (
+				<div className="space-y-3">
+					<div className="flex gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={() => setShowMacroDialogMd(true)}
+						>
+							<Gamepad2 className="h-4 w-4 mr-1" />
+							マクロ挿入
+						</Button>
+					</div>
+					<ImageUploader onInsert={handleImageInsert} />
+				</div>
+			)}
+
+			{showMacroDialogMd && (
+				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+					<div className="w-full max-w-lg rounded-lg border border-border bg-background p-6 shadow-lg">
+						<h3 className="text-lg font-semibold mb-4">FF14マクロを挿入</h3>
+						<div className="space-y-3">
+							<textarea
+								value={macroTextMd}
+								onChange={(e) => {
+									const lines = e.target.value.split('\n');
+									if (lines.length <= 15) {
+										setMacroTextMd(e.target.value);
+									}
+								}}
+								placeholder={'/ac アクション名 <wait.3>\n/p メッセージ <se.1>'}
+								className="w-full h-48 rounded-md border border-input bg-[#1a1a2e] px-3 py-2 text-sm font-mono text-[#c8d0d8] placeholder:text-[#4a5568] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 outline-none resize-none"
+								// biome-ignore lint/a11y/noAutofocus: Macro dialog textarea needs immediate focus
+								autoFocus
+							/>
+							<div className="flex items-center justify-between text-xs text-muted-foreground">
+								<span>各行が / で始まるマクロコマンドです</span>
+								<span className={macroLineCountMd > 15 ? 'text-destructive' : ''}>
+									{macroLineCountMd}/15行
+								</span>
+							</div>
+						</div>
+						<div className="flex justify-end gap-2 mt-4">
+							<Button type="button" variant="outline" onClick={cancelMacroMd}>
+								キャンセル
+							</Button>
+							<Button type="button" onClick={insertMacroMd} disabled={!macroTextMd.trim()}>
+								挿入
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
 
 			{/* Submit buttons */}
 			<div className="flex flex-wrap gap-3 justify-end pt-4 border-t border-border">

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -2,6 +2,7 @@ import type { Editor } from '@tiptap/react';
 import {
 	Bold,
 	Code,
+	Gamepad2,
 	Heading1,
 	Heading2,
 	Heading3,
@@ -18,11 +19,30 @@ import { Button } from '@/components/ui/button';
 
 interface EditorToolbarProps {
 	editor: Editor;
+	onInsertMacro: (macro: string) => void;
 }
 
-export function EditorToolbar({ editor }: EditorToolbarProps) {
+export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 	const [linkUrl, setLinkUrl] = useState('');
 	const [showLinkInput, setShowLinkInput] = useState(false);
+	const [showMacroDialog, setShowMacroDialog] = useState(false);
+	const [macroText, setMacroText] = useState('');
+
+	const macroLineCount = macroText ? macroText.split('\n').length : 0;
+
+	const insertMacro = useCallback(() => {
+		if (macroText.trim()) {
+			onInsertMacro(macroText.trim());
+		}
+		setMacroText('');
+		setShowMacroDialog(false);
+	}, [macroText, onInsertMacro]);
+
+	const cancelMacro = useCallback(() => {
+		setMacroText('');
+		setShowMacroDialog(false);
+		editor.chain().focus().run();
+	}, [editor]);
 
 	const toggleLink = useCallback(() => {
 		if (editor.isActive('link')) {
@@ -120,6 +140,12 @@ export function EditorToolbar({ editor }: EditorToolbarProps) {
 			>
 				<Code className="h-4 w-4" />
 			</ToolbarButton>
+
+			<ToolbarSeparator />
+
+			<ToolbarButton onClick={() => setShowMacroDialog(true)} active={false} title="マクロ挿入">
+				<Gamepad2 className="h-4 w-4" />
+			</ToolbarButton>
 			<ToolbarButton onClick={toggleLink} active={editor.isActive('link')} title="リンク">
 				<Link className="h-4 w-4" />
 			</ToolbarButton>
@@ -164,6 +190,43 @@ export function EditorToolbar({ editor }: EditorToolbarProps) {
 					<Button type="button" variant="ghost" size="xs" onClick={cancelLink}>
 						取消
 					</Button>
+				</div>
+			)}
+
+			{showMacroDialog && (
+				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+					<div className="w-full max-w-lg rounded-lg border border-border bg-background p-6 shadow-lg">
+						<h3 className="text-lg font-semibold mb-4">FF14マクロを挿入</h3>
+						<div className="space-y-3">
+							<textarea
+								value={macroText}
+								onChange={(e) => {
+									const lines = e.target.value.split('\n');
+									if (lines.length <= 15) {
+										setMacroText(e.target.value);
+									}
+								}}
+								placeholder={'/ac アクション名 <wait.3>\n/p メッセージ <se.1>'}
+								className="w-full h-48 rounded-md border border-input bg-[#1a1a2e] px-3 py-2 text-sm font-mono text-[#c8d0d8] placeholder:text-[#4a5568] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 outline-none resize-none"
+								// biome-ignore lint/a11y/noAutofocus: Macro dialog textarea needs immediate focus
+								autoFocus
+							/>
+							<div className="flex items-center justify-between text-xs text-muted-foreground">
+								<span>各行が / で始まるマクロコマンドです</span>
+								<span className={macroLineCount > 15 ? 'text-destructive' : ''}>
+									{macroLineCount}/15行
+								</span>
+							</div>
+						</div>
+						<div className="flex justify-end gap-2 mt-4">
+							<Button type="button" variant="outline" onClick={cancelMacro}>
+								キャンセル
+							</Button>
+							<Button type="button" onClick={insertMacro} disabled={!macroText.trim()}>
+								挿入
+							</Button>
+						</div>
+					</div>
 				</div>
 			)}
 		</div>

--- a/src/components/editor/MarkdownPreview.tsx
+++ b/src/components/editor/MarkdownPreview.tsx
@@ -1,8 +1,20 @@
 import DOMPurify from 'dompurify';
 import { Marked } from 'marked';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-const marked = new Marked();
+import { renderMacroBlock } from '../../lib/macro-highlight';
+
+const marked = new Marked({
+	renderer: {
+		code({ text, lang }: { text: string; lang?: string | undefined }) {
+			if (lang === 'ffxiv-macro') {
+				return renderMacroBlock(text);
+			}
+			const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+			return `<pre><code>${escaped}</code></pre>`;
+		},
+	},
+});
 
 interface MarkdownPreviewProps {
 	body: string;
@@ -16,7 +28,12 @@ export function MarkdownPreview({ body }: MarkdownPreviewProps) {
 
 		async function render() {
 			const raw = await marked.parse(body);
-			const sanitized = DOMPurify.sanitize(raw, { FORCE_BODY: true });
+			// Content is sanitized via DOMPurify to prevent XSS
+			const sanitized = DOMPurify.sanitize(raw, {
+				FORCE_BODY: true,
+				ADD_TAGS: ['button'],
+				ADD_ATTR: ['data-macro-text', 'class'],
+			});
 			if (!cancelled) {
 				setHtml(sanitized);
 			}
@@ -28,9 +45,30 @@ export function MarkdownPreview({ body }: MarkdownPreviewProps) {
 		};
 	}, [body]);
 
+	const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+		const target = e.target as HTMLElement;
+		if (!target.classList.contains('ffxiv-macro-copy')) return;
+
+		const macroText = target.getAttribute('data-macro-text');
+		if (!macroText) return;
+
+		navigator.clipboard.writeText(macroText).then(() => {
+			const originalText = target.textContent;
+			target.textContent = 'コピー済み';
+			target.setAttribute('data-copied', 'true');
+			setTimeout(() => {
+				target.textContent = originalText;
+				target.removeAttribute('data-copied');
+			}, 2000);
+		});
+	}, []);
+
 	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: Copy button click delegation, not interactive content
+		// biome-ignore lint/a11y/noStaticElementInteractions: Event delegation for copy buttons inside rendered HTML
 		<div
 			className="article-content prose-preview"
+			onClick={handleClick}
 			// biome-ignore lint/security/noDangerouslySetInnerHtml: Content sanitized via DOMPurify
 			dangerouslySetInnerHTML={{ __html: html }}
 		/>

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -2,15 +2,17 @@ import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
+import { useCallback } from 'react';
 import { Markdown } from 'tiptap-markdown';
 import { EditorToolbar } from './EditorToolbar';
 
 interface RichTextEditorProps {
 	content: string;
 	onChange: (markdown: string) => void;
+	onInsertMacro?: (macro: string) => void;
 }
 
-export function RichTextEditor({ content, onChange }: RichTextEditorProps) {
+export function RichTextEditor({ content, onChange, onInsertMacro }: RichTextEditorProps) {
 	const editor = useEditor({
 		extensions: [
 			StarterKit.configure({
@@ -42,6 +44,23 @@ export function RichTextEditor({ content, onChange }: RichTextEditorProps) {
 		},
 	});
 
+	const handleInsertMacro = useCallback(
+		(macro: string) => {
+			if (!editor) return;
+			if (onInsertMacro) {
+				onInsertMacro(macro);
+			} else {
+				// Fallback: append macro block via Markdown storage
+				const storage = editor.storage as unknown as Record<string, { getMarkdown: () => string }>;
+				const currentMd = storage.markdown.getMarkdown();
+				const macroBlock = `\n\n\`\`\`ffxiv-macro\n${macro}\n\`\`\`\n`;
+				const newMd = currentMd + macroBlock;
+				onChange(newMd);
+			}
+		},
+		[editor, onInsertMacro, onChange],
+	);
+
 	if (!editor) {
 		return (
 			<div className="flex flex-col">
@@ -53,7 +72,7 @@ export function RichTextEditor({ content, onChange }: RichTextEditorProps) {
 
 	return (
 		<div className="flex flex-col">
-			<EditorToolbar editor={editor} />
+			<EditorToolbar editor={editor} onInsertMacro={handleInsertMacro} />
 			<div className="h-[500px] overflow-y-auto rounded-b-md border border-input px-4 py-3 dark:bg-input/30">
 				<EditorContent editor={editor} />
 			</div>

--- a/src/lib/macro-highlight.ts
+++ b/src/lib/macro-highlight.ts
@@ -1,0 +1,98 @@
+/**
+ * FF14 マクロブロックのシンタックスハイライトとHTML生成
+ * サーバーサイド (markdown.ts) とクライアントサイド (MarkdownPreview.tsx) で共用
+ */
+
+/**
+ * HTML属性用のエスケープ（data-macro-text 等に使用）
+ */
+function escapeHtmlAttr(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/"/g, '&quot;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
+/**
+ * HTMLコンテンツ用のエスケープ
+ */
+function escapeHtml(text: string): string {
+	return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * マクロの1行をシンタックスハイライトする
+ *
+ * ルール:
+ * - `/` で始まるコマンド部分（最初のスペースまで）: <span class="macro-command">
+ * - `<...>` プレースホルダー: <span class="macro-placeholder">
+ * - それ以外: <span class="macro-text">
+ */
+export function highlightMacroLine(line: string): string {
+	if (line.length === 0) {
+		return '';
+	}
+
+	let result = '';
+	let pos = 0;
+
+	// コマンド部分の処理: 行が `/` で始まる場合
+	if (line.startsWith('/')) {
+		const spaceIndex = line.indexOf(' ');
+		const commandEnd = spaceIndex === -1 ? line.length : spaceIndex;
+		const command = line.slice(0, commandEnd);
+		result += `<span class="macro-command">${escapeHtml(command)}</span>`;
+		pos = commandEnd;
+	}
+
+	// 残りの部分を処理
+	while (pos < line.length) {
+		const char = line[pos];
+
+		if (char === '<') {
+			// <...> プレースホルダーを検出
+			const closeIndex = line.indexOf('>', pos);
+			if (closeIndex !== -1) {
+				const placeholder = line.slice(pos, closeIndex + 1);
+				result += `<span class="macro-placeholder">${escapeHtml(placeholder)}</span>`;
+				pos = closeIndex + 1;
+				continue;
+			}
+		}
+
+		// 通常テキストを蓄積（次の `<` まで、または行末まで）
+		let textEnd = pos + 1;
+		while (textEnd < line.length && line[textEnd] !== '<') {
+			textEnd++;
+		}
+		const text = line.slice(pos, textEnd);
+		result += `<span class="macro-text">${escapeHtml(text)}</span>`;
+		pos = textEnd;
+	}
+
+	return result;
+}
+
+/**
+ * マクロテキスト全体からHTMLブロックを生成する
+ */
+export function renderMacroBlock(text: string): string {
+	const lines = text.split('\n');
+	const lineCount = lines.length;
+
+	const highlightedLines = lines.map((line) => highlightMacroLine(line)).join('\n');
+
+	const escapedMacroText = escapeHtmlAttr(text);
+
+	return `<div class="ffxiv-macro-block">
+  <div class="ffxiv-macro-header">
+    <span class="ffxiv-macro-label">FFXIV マクロ</span>
+    <button class="ffxiv-macro-copy" data-macro-text="${escapedMacroText}">コピー</button>
+  </div>
+  <pre class="ffxiv-macro-code"><code>${highlightedLines}</code></pre>
+  <div class="ffxiv-macro-footer">
+    <span class="ffxiv-macro-line-count">${lineCount}/15行</span>
+  </div>
+</div>`;
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -3,6 +3,8 @@ import { createHighlighterCore, type HighlighterCore } from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 import vitesseDark from 'shiki/themes/vitesse-dark.mjs';
 
+import { renderMacroBlock } from './macro-highlight';
+
 let highlighterPromise: Promise<HighlighterCore> | null = null;
 
 function getHighlighter(): Promise<HighlighterCore> {
@@ -35,6 +37,11 @@ export async function renderMarkdown(markdown: string): Promise<string> {
 
 	const renderer = {
 		code({ text, lang }: { text: string; lang?: string | undefined }) {
+			// FF14マクロブロックは専用レンダラーで処理
+			if (lang === 'ffxiv-macro') {
+				return renderMacroBlock(text);
+			}
+
 			const language = lang || 'text';
 			try {
 				const loadedLangs: string[] = highlighter.getLoadedLanguages();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -369,3 +369,97 @@
 	height: 0;
 	pointer-events: none;
 }
+
+/* FF14 Macro Block styles */
+.ffxiv-macro-block {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  background-color: #1a1a2e;  /* FF14風のダークブルー */
+}
+
+.ffxiv-macro-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background-color: #16213e;
+  border-bottom: 1px solid #0f3460;
+}
+
+.ffxiv-macro-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #e0c080;  /* FF14のゴールドっぽい色 */
+  letter-spacing: 0.05em;
+}
+
+.ffxiv-macro-copy {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 0.25rem;
+  border: 1px solid #0f3460;
+  background-color: #0f3460;
+  color: #a0b4d0;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.ffxiv-macro-copy:hover {
+  background-color: #1a4080;
+  color: #e0e0e0;
+}
+
+.ffxiv-macro-copy[data-copied="true"] {
+  background-color: #2d5016;
+  border-color: #3d6b20;
+  color: #90d060;
+}
+
+.ffxiv-macro-code {
+  margin: 0 !important;
+  padding: 0.75rem 1rem !important;
+  background-color: #1a1a2e !important;
+  border: none !important;
+  border-radius: 0 !important;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.8125rem !important;
+  line-height: 1.7 !important;
+  overflow-x: auto;
+}
+
+.ffxiv-macro-code code {
+  background-color: transparent !important;
+  padding: 0 !important;
+  font-size: inherit !important;
+}
+
+.ffxiv-macro-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.375rem 0.75rem;
+  background-color: #16213e;
+  border-top: 1px solid #0f3460;
+}
+
+.ffxiv-macro-line-count {
+  font-size: 0.6875rem;
+  color: #6080a0;
+}
+
+/* Syntax highlighting colors */
+.macro-command {
+  color: #7cacf8;  /* コマンド: 青系 */
+  font-weight: 600;
+}
+
+.macro-placeholder {
+  color: #f0a050;  /* プレースホルダー: オレンジ系 */
+}
+
+.macro-text {
+  color: #c8d0d8;  /* 通常テキスト: 薄いグレー */
+}


### PR DESCRIPTION
## Summary

- 記事エディタにFF14マクロブロックの挿入・表示機能を追加
- Markdownで ` ```ffxiv-macro ` コードブロックとして記述し、専用UIでレンダリング
- ビジュアル/Markdownモード両方でマクロ挿入ダイアログを利用可能

## 変更内容

### 新規ファイル
- `src/lib/macro-highlight.ts` — マクロのシンタックスハイライトとHTML生成の共通モジュール

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `src/lib/markdown.ts` | `ffxiv-macro` コードブロックの専用レンダラーを追加 |
| `src/components/editor/MarkdownPreview.tsx` | プレビューでのマクロブロック表示 + コピーボタン対応 |
| `src/components/editor/EditorToolbar.tsx` | ツールバーにマクロ挿入ボタン + ダイアログ追加 |
| `src/components/editor/RichTextEditor.tsx` | `onInsertMacro` props でマクロ挿入に対応 |
| `src/components/editor/ArticleEditor.tsx` | ビジュアル/Markdownモードのマクロ挿入ハンドリング |
| `src/components/ArticleContent.astro` | 記事表示のマクロブロックCSS + コピースクリプト |
| `src/styles/global.css` | プレビュー・エディタ用マクロブロックCSS |

### 機能詳細
- **シンタックスハイライト**: コマンド（青）、プレースホルダー（オレンジ）、テキスト（グレー）で色分け
- **コピーボタン**: ワンクリックでマクロ全文をクリップボードにコピー（2秒間「コピー済み」表示）
- **15行制限**: マクロ入力ダイアログで15行制限をリアルタイムバリデーション
- **FF14風ダークテーマ**: ダークブルー背景 + ゴールドのラベルで視覚的に区別

Closes #80

## Test plan
- [ ] ビジュアルモードのツールバーからマクロ挿入ダイアログを開ける
- [ ] Markdownモードのマクロ挿入ボタンからダイアログを開ける
- [ ] 15行を超えるマクロが入力できないことを確認
- [ ] 挿入したマクロが記事プレビューで専用UIで表示される
- [ ] コピーボタンでマクロテキストがクリップボードにコピーされる
- [ ] 記事公開後、表示ページでもマクロブロックが正しくレンダリングされる
- [ ] モバイル表示でマクロブロックが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)