### PR TITLE
fix: ビジュアルエディタでマクロブロックのシンタックスハイライトを表示 (#83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@supabase/ssr": "^0.9.0",
 		"@supabase/supabase-js": "^2.98.0",
 		"@tailwindcss/vite": "^4.2.1",
+		"@tiptap/extension-code-block": "^3.20.0",
 		"@tiptap/extension-link": "^3.20.0",
 		"@tiptap/extension-placeholder": "^3.20.0",
 		"@tiptap/pm": "^3.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@tiptap/extension-code-block':
+        specifier: ^3.20.0
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-link':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)

--- a/src/components/editor/MacroBlockNodeView.tsx
+++ b/src/components/editor/MacroBlockNodeView.tsx
@@ -1,0 +1,171 @@
+import type { NodeViewProps } from '@tiptap/react';
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
+import { Pencil, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { highlightMacroLine } from '../../lib/macro-highlight';
+
+export function MacroBlockNodeView({ node, editor, getPos }: NodeViewProps) {
+	const language = node.attrs.language as string | undefined;
+
+	if (language !== 'ffxiv-macro') {
+		return (
+			<NodeViewWrapper as="pre">
+				<NodeViewContent<'code'> as="code" />
+			</NodeViewWrapper>
+		);
+	}
+
+	return <MacroPreview node={node} editor={editor} getPos={getPos} />;
+}
+
+function MacroPreview({ node, editor, getPos }: Pick<NodeViewProps, 'node' | 'editor' | 'getPos'>) {
+	const text = node.textContent;
+	const lines = text.split('\n');
+	const lineCount = lines.length;
+	// highlightMacroLine escapes all HTML entities before wrapping in span tags
+	const highlighted = lines.map((line) => highlightMacroLine(line)).join('\n');
+
+	const [editing, setEditing] = useState(false);
+	const [editText, setEditText] = useState(text);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		setEditText(text);
+	}, [text]);
+
+	useEffect(() => {
+		if (editing && textareaRef.current) {
+			textareaRef.current.focus();
+		}
+	}, [editing]);
+
+	const editLineCount = editText ? editText.split('\n').length : 0;
+
+	const handleSave = useCallback(() => {
+		const pos = getPos();
+		if (pos === undefined) return;
+		const trimmed = editText.trim();
+		if (!trimmed) return;
+
+		editor
+			.chain()
+			.command(({ tr, dispatch }) => {
+				if (dispatch) {
+					const newNode = editor.schema.nodes.codeBlock.create(
+						{ language: 'ffxiv-macro' },
+						trimmed ? editor.schema.text(trimmed) : undefined,
+					);
+					tr.replaceWith(pos, pos + node.nodeSize, newNode);
+				}
+				return true;
+			})
+			.run();
+		setEditing(false);
+	}, [editText, editor, getPos, node.nodeSize]);
+
+	const handleDelete = useCallback(() => {
+		const pos = getPos();
+		if (pos === undefined) return;
+		editor
+			.chain()
+			.command(({ tr, dispatch }) => {
+				if (dispatch) {
+					tr.delete(pos, pos + node.nodeSize);
+				}
+				return true;
+			})
+			.run();
+	}, [editor, getPos, node.nodeSize]);
+
+	const handleCancel = useCallback(() => {
+		setEditText(text);
+		setEditing(false);
+	}, [text]);
+
+	if (editing) {
+		return (
+			<NodeViewWrapper>
+				<div className="ffxiv-macro-block" contentEditable={false}>
+					<div className="ffxiv-macro-header">
+						<span className="ffxiv-macro-label">FFXIV マクロ - 編集中</span>
+					</div>
+					<div style={{ padding: '0.75rem 1rem' }}>
+						<textarea
+							ref={textareaRef}
+							value={editText}
+							onChange={(e) => {
+								const newLines = e.target.value.split('\n');
+								if (newLines.length <= 15) {
+									setEditText(e.target.value);
+								}
+							}}
+							onKeyDown={(e) => {
+								if (e.key === 'Escape') handleCancel();
+								if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSave();
+							}}
+							className="w-full h-40 rounded-md border border-[#0f3460] bg-[#12122a] px-3 py-2 text-sm font-mono text-[#c8d0d8] placeholder:text-[#4a5568] outline-none resize-none"
+							placeholder="/ac アクション名 <wait.3>"
+						/>
+						<div className="flex items-center justify-between mt-2">
+							<span className={`text-xs ${editLineCount > 15 ? 'text-red-400' : 'text-[#6080a0]'}`}>
+								{editLineCount}/15行（Ctrl+Enter で保存）
+							</span>
+							<div className="flex gap-2">
+								<button
+									type="button"
+									onClick={handleCancel}
+									className="px-3 py-1 text-xs rounded border border-[#0f3460] text-[#a0b4d0] hover:bg-[#1a4080]"
+								>
+									キャンセル
+								</button>
+								<button
+									type="button"
+									onClick={handleSave}
+									disabled={!editText.trim()}
+									className="px-3 py-1 text-xs rounded bg-[#0f3460] text-[#a0b4d0] hover:bg-[#1a4080] disabled:opacity-40"
+								>
+									保存
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</NodeViewWrapper>
+		);
+	}
+
+	return (
+		<NodeViewWrapper>
+			<div className="ffxiv-macro-block" contentEditable={false}>
+				<div className="ffxiv-macro-header">
+					<span className="ffxiv-macro-label">FFXIV マクロ</span>
+					<div className="ffxiv-macro-actions">
+						<button
+							type="button"
+							className="ffxiv-macro-action-btn"
+							onClick={() => setEditing(true)}
+							title="編集"
+						>
+							<Pencil size={12} />
+						</button>
+						<button
+							type="button"
+							className="ffxiv-macro-action-btn"
+							onClick={handleDelete}
+							title="削除"
+						>
+							<Trash2 size={12} />
+						</button>
+					</div>
+				</div>
+				<pre className="ffxiv-macro-code">
+					{/* biome-ignore lint/security/noDangerouslySetInnerHtml: Macro text is HTML-escaped by highlightMacroLine before wrapping in span tags */}
+					<code dangerouslySetInnerHTML={{ __html: highlighted }} />
+				</pre>
+				<div className="ffxiv-macro-footer">
+					<span className="ffxiv-macro-line-count">{lineCount}/15行</span>
+				</div>
+			</div>
+		</NodeViewWrapper>
+	);
+}

--- a/src/components/editor/MacroCodeBlock.ts
+++ b/src/components/editor/MacroCodeBlock.ts
@@ -1,0 +1,9 @@
+import CodeBlock from '@tiptap/extension-code-block';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { MacroBlockNodeView } from './MacroBlockNodeView';
+
+export const MacroCodeBlock = CodeBlock.extend({
+	addNodeView() {
+		return ReactNodeViewRenderer(MacroBlockNodeView);
+	},
+});

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -5,6 +5,7 @@ import StarterKit from '@tiptap/starter-kit';
 import { useCallback } from 'react';
 import { Markdown } from 'tiptap-markdown';
 import { EditorToolbar } from './EditorToolbar';
+import { MacroCodeBlock } from './MacroCodeBlock';
 
 interface RichTextEditorProps {
 	content: string;
@@ -17,7 +18,9 @@ export function RichTextEditor({ content, onChange, onInsertMacro }: RichTextEdi
 		extensions: [
 			StarterKit.configure({
 				heading: { levels: [1, 2, 3] },
+				codeBlock: false,
 			}),
+			MacroCodeBlock,
 			Link.configure({
 				openOnClick: false,
 				HTMLAttributes: { rel: 'noopener noreferrer nofollow', target: '_blank' },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -463,3 +463,28 @@
 .macro-text {
   color: #c8d0d8;  /* 通常テキスト: 薄いグレー */
 }
+
+/* Macro block action buttons (visual editor) */
+.ffxiv-macro-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.ffxiv-macro-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid #0f3460;
+  background-color: #0f3460;
+  color: #a0b4d0;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.ffxiv-macro-action-btn:hover {
+  background-color: #1a4080;
+  color: #e0e0e0;
+}


### PR DESCRIPTION
## Summary

- ビジュアルエディタ（TipTap）で `ffxiv-macro` コードブロックが通常のコードブロックとして表示される問題を修正
- カスタム NodeView により、エディタ内でもFF14マクロ専用のシンタックスハイライト・スタイリングが適用されるように

## 変更内容

### 新規ファイル
| ファイル | 説明 |
|---------|------|
| `MacroBlockNodeView.tsx` | TipTap ReactNodeView コンポーネント。`ffxiv-macro` 言語のコードブロックをシンタックスハイライト付きで表示。編集・削除ボタン付き |
| `MacroCodeBlock.ts` | CodeBlock を拡張し、カスタム NodeView を登録する TipTap Extension |

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `RichTextEditor.tsx` | StarterKit の codeBlock を無効化し、MacroCodeBlock に置き換え |
| `global.css` | NodeView のアクションボタン（編集・削除）用 CSS 追加 |
| `package.json` | `@tiptap/extension-code-block` を直接依存に追加 |

### 動作仕様
- **通常のコードブロック**: デフォルトの TipTap 表示（`NodeViewContent` で編集可能）
- **ffxiv-macro コードブロック**: 
  - FF14風ダークブルーテーマで表示
  - コマンド（青）・プレースホルダー（オレンジ）・テキスト（グレー）のシンタックスハイライト
  - ヘッダーに編集・削除ボタン
  - 編集ボタンでインライン編集モード（15行制限、Ctrl+Enter で保存）
  - フッターに行数カウント

Closes #83

## Test plan
- [ ] ビジュアルモードでマクロ挿入後、FF14風スタイリングで表示される
- [ ] シンタックスハイライト（コマンド青・プレースホルダーオレンジ）が適用される
- [ ] 編集ボタンでインライン編集モードに切り替わる
- [ ] 編集モードで15行制限が動作する
- [ ] Ctrl+Enter で編集を保存できる
- [ ] 削除ボタンでマクロブロックを削除できる
- [ ] 通常のコードブロック（非マクロ）は従来通り動作する
- [ ] Markdownモード・プレビュー・記事表示には影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)