### PR TITLE
feat: 散開図のビジュアルエディタ内編集機能を追加 (#87)

### DIFF
--- a/src/components/diagram/DiagramModal.tsx
+++ b/src/components/diagram/DiagramModal.tsx
@@ -6,18 +6,27 @@ import type { DiagramData } from './types';
 interface DiagramModalProps {
 	isOpen: boolean;
 	onClose: () => void;
-	onInsert: (codeFence: string) => void;
+	onInsert?: (codeFence: string) => void;
+	onSave?: (json: string) => void;
+	initialData?: DiagramData;
 }
 
-const INITIAL_DATA: DiagramData = {
+const EMPTY_DATA: DiagramData = {
 	fieldType: 'circle',
 	markers: [],
 	waymarks: [],
 };
 
-export function DiagramModal({ isOpen, onClose, onInsert }: DiagramModalProps) {
-	const [data, setData] = useState<DiagramData>(INITIAL_DATA);
+export function DiagramModal({
+	isOpen,
+	onClose,
+	onInsert,
+	onSave,
+	initialData,
+}: DiagramModalProps) {
+	const [data, setData] = useState<DiagramData>(initialData ?? EMPTY_DATA);
 	const [editorKey, setEditorKey] = useState(0);
+	const isEditMode = !!onSave;
 	const overlayRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -54,15 +63,19 @@ export function DiagramModal({ isOpen, onClose, onInsert }: DiagramModalProps) {
 		[onClose],
 	);
 
-	const handleInsert = useCallback(() => {
-		const json = JSON.stringify(data);
-		const codeFence = `\`\`\`diagram\n${json}\n\`\`\``;
-		onInsert(codeFence);
+	const handleSubmit = useCallback(() => {
+		if (isEditMode && onSave) {
+			onSave(JSON.stringify(data));
+		} else if (onInsert) {
+			const json = JSON.stringify(data);
+			const codeFence = `\`\`\`diagram\n${json}\n\`\`\``;
+			onInsert(codeFence);
+		}
 		onClose();
-	}, [data, onInsert, onClose]);
+	}, [data, isEditMode, onSave, onInsert, onClose]);
 
 	const handleClear = useCallback(() => {
-		setData({ ...INITIAL_DATA });
+		setData({ ...EMPTY_DATA });
 		setEditorKey((k) => k + 1);
 	}, []);
 
@@ -93,8 +106,8 @@ export function DiagramModal({ isOpen, onClose, onInsert }: DiagramModalProps) {
 						<Button type="button" variant="outline" onClick={onClose}>
 							キャンセル
 						</Button>
-						<Button type="button" onClick={handleInsert}>
-							挿入
+						<Button type="button" onClick={handleSubmit}>
+							{isEditMode ? '更新' : '挿入'}
 						</Button>
 					</div>
 				</div>

--- a/src/components/editor/extensions/DiagramBlock.tsx
+++ b/src/components/editor/extensions/DiagramBlock.tsx
@@ -1,18 +1,21 @@
 import CodeBlock from '@tiptap/extension-code-block';
 import type { NodeViewProps } from '@tiptap/react';
 import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
-import { Trash2 } from 'lucide-react';
-import { useCallback, useMemo } from 'react';
+import { Pencil, Trash2 } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { DiagramModal } from '@/components/diagram/DiagramModal';
 import { parseDiagramJson, renderDiagramSvg } from '@/components/diagram/renderDiagramSvg';
 
 function DiagramNodeView({ node, editor, getPos, selected }: NodeViewProps) {
 	const text = node.textContent;
+	const [editing, setEditing] = useState(false);
+
+	const diagramData = useMemo(() => parseDiagramJson(text) ?? undefined, [text]);
 
 	const svgHtml = useMemo(() => {
-		const data = parseDiagramJson(text);
-		if (!data) return null;
-		return renderDiagramSvg(data);
-	}, [text]);
+		if (!diagramData) return null;
+		return renderDiagramSvg(diagramData);
+	}, [diagramData]);
 
 	const handleDelete = useCallback(() => {
 		const pos = getPos();
@@ -27,6 +30,28 @@ function DiagramNodeView({ node, editor, getPos, selected }: NodeViewProps) {
 			})
 			.run();
 	}, [editor, getPos, node.nodeSize]);
+
+	const handleSave = useCallback(
+		(newJson: string) => {
+			const pos = getPos();
+			if (pos === undefined) return;
+			editor
+				.chain()
+				.command(({ tr, dispatch }) => {
+					if (dispatch) {
+						const newNode = editor.schema.nodes.diagramBlock.create(
+							{ language: 'diagram' },
+							newJson ? editor.schema.text(newJson) : undefined,
+						);
+						tr.replaceWith(pos, pos + node.nodeSize, newNode);
+					}
+					return true;
+				})
+				.run();
+			setEditing(false);
+		},
+		[editor, getPos, node.nodeSize],
+	);
 
 	if (!svgHtml) {
 		return (
@@ -59,20 +84,38 @@ function DiagramNodeView({ node, editor, getPos, selected }: NodeViewProps) {
 			>
 				<div className="diagram-preview-header">
 					<span className="diagram-preview-label">散開図</span>
-					<button
-						type="button"
-						className="diagram-preview-action-btn"
-						onClick={handleDelete}
-						title="削除"
-					>
-						<Trash2 size={12} />
-					</button>
+					<div className="diagram-preview-actions">
+						<button
+							type="button"
+							className="diagram-preview-action-btn"
+							onClick={() => setEditing(true)}
+							title="編集"
+						>
+							<Pencil size={12} />
+						</button>
+						<button
+							type="button"
+							className="diagram-preview-action-btn"
+							onClick={handleDelete}
+							title="削除"
+						>
+							<Trash2 size={12} />
+						</button>
+					</div>
 				</div>
 				<div className="diagram-preview-body">
 					{/* biome-ignore lint/security/noDangerouslySetInnerHtml: SVG is generated from validated DiagramData via parseDiagramJson + renderDiagramSvg; input is JSON-parsed and type-checked, not raw user HTML */}
 					<div className="diagram-container" dangerouslySetInnerHTML={{ __html: svgHtml }} />
 				</div>
 			</div>
+			{editing && (
+				<DiagramModal
+					isOpen={true}
+					initialData={diagramData}
+					onSave={handleSave}
+					onClose={() => setEditing(false)}
+				/>
+			)}
 		</NodeViewWrapper>
 	);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -416,6 +416,11 @@
   letter-spacing: 0.05em;
 }
 
+.diagram-preview-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
 .diagram-preview-action-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- DiagramNodeView に Pencil アイコンの編集ボタンを追加し、クリック時に DiagramModal を編集モードで表示
- DiagramModal に `initialData` / `onSave` prop を追加し、既存データの編集と「更新」ボタン表示に対応
- 保存時に ProseMirror ノードのテキストコンテンツを新しい JSON に差し替え
- 既存の新規挿入フロー（`onInsert`）は後方互換で動作

Closes #87

## Test plan
- [ ] ビジュアルエディタで散開図プレビューに編集ボタン（Pencil アイコン）が表示される
- [ ] 編集ボタンクリックで DiagramModal が既存データを読み込んだ状態で開く
- [ ] モーダルで編集後「更新」を押すとプレビューが即座に更新される
- [ ] 「キャンセル」を押すと変更が破棄されプレビューは元のまま
- [ ] 既存の新規挿入フロー（ArticleEditor → DiagramModal → 挿入）に影響がない
- [ ] Markdown モードに切り替えた際、更新後の JSON が正しくコードフェンスに反映されている
- [ ] `pnpm biome check .` / `pnpm check` / `pnpm build` がすべて通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)