### PR TITLE
fix: 散開図エディタのUIテキストが選択可能な問題を修正 (#90)

### DIFF
--- a/src/components/diagram/DiagramModal.tsx
+++ b/src/components/diagram/DiagramModal.tsx
@@ -81,7 +81,7 @@ export function DiagramModal({ isOpen, onClose, onInsert }: DiagramModalProps) {
 			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
 		>
 			<div className="relative w-full max-w-3xl mx-4 rounded-lg border border-border bg-background p-6 shadow-lg">
-				<h2 className="text-lg font-semibold mb-4">散開図エディタ</h2>
+				<h2 className="text-lg font-semibold mb-4 select-none">散開図エディタ</h2>
 
 				<DiagramEditor key={editorKey} initialData={data} onChange={setData} />
 

--- a/src/components/diagram/DiagramPalette.tsx
+++ b/src/components/diagram/DiagramPalette.tsx
@@ -19,7 +19,7 @@ export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPal
 		<div className="flex flex-col gap-4">
 			{/* ロールセクション */}
 			<div>
-				<h3 className="mb-2 text-sm font-semibold text-muted-foreground">ロール</h3>
+				<h3 className="mb-2 text-sm font-semibold text-muted-foreground select-none">ロール</h3>
 				<div className="flex flex-wrap gap-2">
 					{ROLES.map((role) => {
 						const placed = existingMarkers.includes(role);
@@ -35,7 +35,7 @@ export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPal
 									e.dataTransfer.setData('type', 'marker');
 									e.dataTransfer.setData('id', role);
 								}}
-								className="inline-flex h-8 w-10 items-center justify-center rounded-full text-xs font-bold text-white"
+								className="inline-flex h-8 w-10 items-center justify-center rounded-full text-xs font-bold text-white select-none"
 								style={{
 									backgroundColor: color,
 									opacity: placed ? 0.3 : 1,
@@ -51,7 +51,9 @@ export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPal
 
 			{/* ウェイマークセクション */}
 			<div>
-				<h3 className="mb-2 text-sm font-semibold text-muted-foreground">ウェイマーク</h3>
+				<h3 className="mb-2 text-sm font-semibold text-muted-foreground select-none">
+					ウェイマーク
+				</h3>
 				<div className="flex flex-wrap gap-2">
 					{WAYMARK_LABELS.map((label) => {
 						const placed = existingWaymarks.includes(label);
@@ -68,7 +70,7 @@ export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPal
 									e.dataTransfer.setData('type', 'waymark');
 									e.dataTransfer.setData('id', label);
 								}}
-								className={`inline-flex h-8 w-8 items-center justify-center text-xs font-bold text-white ${
+								className={`inline-flex h-8 w-8 items-center justify-center text-xs font-bold text-white select-none ${
 									isNumber ? 'rounded-sm' : 'rounded-full'
 								}`}
 								style={{


### PR DESCRIPTION
## Summary
- DiagramModal の「散開図エディタ」見出しに `select-none` を追加
- DiagramPalette の「ロール」「ウェイマーク」見出しに `select-none` を追加
- パレット内のロール・ウェイマークアイコン（span要素）に `select-none` を追加

Closes #90

## Test plan
- [ ] モーダルの「散開図エディタ」見出しが選択不可
- [ ] パレットの「ロール」「ウェイマーク」見出しが選択不可
- [ ] パレットのアイコン内テキスト（MT, ST, A, B 等）が選択不可
- [ ] ドラッグ操作時にテキスト選択が発生しない
- [ ] 散開図フィールド（SVG）の操作に影響がない
- [ ] `pnpm biome check .` / `pnpm check` / `pnpm build` がすべて通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)