### PR TITLE
fix: 散開図プレビューヘッダーのテキスト選択を無効化 (#92)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -407,6 +407,7 @@
   padding: 0.5rem 0.75rem;
   background-color: #16213e;
   border-bottom: 1px solid #0f3460;
+  user-select: none;
 }
 
 .diagram-preview-label {


### PR DESCRIPTION
## Summary
- ビジュアルエディタ内の散開図インラインプレビューで、ヘッダー部分（「散開図」ラベル・編集/削除アイコン）が選択可能だった問題を修正
- `.diagram-preview-header` に `user-select: none` を追加

Closes #92

## Test plan
- [ ] インラインプレビューの「散開図」ラベルが選択不可
- [ ] 編集・削除アイコンが選択不可
- [ ] ドラッグ操作時にテキスト選択が発生しない
- [ ] 編集・削除ボタンのクリック操作に影響なし
- [ ] `pnpm biome check .` / `pnpm check` / `pnpm build` がすべて通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)