### PR TITLE
fix: 散開図プレビューのテキスト選択をonMouseDownで防止 (#92)

### DIFF
--- a/src/components/editor/extensions/DiagramBlock.tsx
+++ b/src/components/editor/extensions/DiagramBlock.tsx
@@ -57,7 +57,11 @@ function DiagramNodeView({ node, editor, getPos, selected }: NodeViewProps) {
 		return (
 			<NodeViewWrapper>
 				<div className="diagram-preview diagram-preview--error" contentEditable={false}>
-					<div className="diagram-preview-header">
+					<div
+						className="diagram-preview-header"
+						role="toolbar"
+						onMouseDown={(e) => e.preventDefault()}
+					>
 						<span className="diagram-preview-label">散開図 - エラー</span>
 						<button
 							type="button"
@@ -82,7 +86,11 @@ function DiagramNodeView({ node, editor, getPos, selected }: NodeViewProps) {
 				className={`diagram-preview${selected ? ' diagram-preview--selected' : ''}`}
 				contentEditable={false}
 			>
-				<div className="diagram-preview-header">
+				<div
+					className="diagram-preview-header"
+					role="toolbar"
+					onMouseDown={(e) => e.preventDefault()}
+				>
 					<span className="diagram-preview-label">散開図</span>
 					<div className="diagram-preview-actions">
 						<button


### PR DESCRIPTION
## Summary
- CSS `user-select: none` は TipTap の `contentEditable` コンテキスト内でブラウザに無視されるため、`onMouseDown` + `preventDefault()` でヘッダー部分のテキスト選択を防止
- `DiagramBlock.tsx` のプレビューヘッダー（正常時・エラー時の両方）に適用
- `role="toolbar"` を追加して biome の a11y lint を通過

Closes #92

## Test plan
- [ ] インラインプレビューの「散開図」ラベルが選択不可
- [ ] 編集・削除アイコンが選択不可
- [ ] ドラッグ操作時にテキスト選択が発生しない
- [ ] 編集・削除ボタンのクリック操作に影響なし
- [ ] `pnpm biome check .` / `pnpm check` / `pnpm build` がすべて通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)