### PR TITLE
fix: パレットからのタッチDnDをPointer APIで対応 (#89)

### DIFF
--- a/src/components/diagram/DiagramEditor.tsx
+++ b/src/components/diagram/DiagramEditor.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+	ROLE_COLORS,
+	type Role,
+	WAYMARK_COLORS,
+	type WaymarkLabel,
+} from '@/components/diagram/constants';
 import { DiagramField } from '@/components/diagram/DiagramField';
 import { DiagramPalette } from '@/components/diagram/DiagramPalette';
 import type { DiagramData } from '@/components/diagram/types';
@@ -16,8 +22,16 @@ const EMPTY_DATA: DiagramData = {
 	waymarks: [],
 };
 
+interface PaletteDrag {
+	type: 'marker' | 'waymark';
+	id: string;
+}
+
 export function DiagramEditor({ initialData, onChange }: DiagramEditorProps) {
 	const [data, setData] = useState<DiagramData>(initialData ?? EMPTY_DATA);
+	const [paletteDrag, setPaletteDrag] = useState<PaletteDrag | null>(null);
+	const [ghostPos, setGhostPos] = useState<{ x: number; y: number } | null>(null);
+	const fieldRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		onChange(data);
@@ -49,9 +63,70 @@ export function DiagramEditor({ initialData, onChange }: DiagramEditorProps) {
 		[data.waymarks],
 	);
 
+	const handlePalettePointerDown = useCallback(
+		(type: 'marker' | 'waymark', id: string, e: React.PointerEvent) => {
+			e.preventDefault();
+			setPaletteDrag({ type, id });
+			setGhostPos({ x: e.clientX, y: e.clientY });
+		},
+		[],
+	);
+
+	useEffect(() => {
+		if (!paletteDrag) return;
+
+		const handlePointerMove = (e: PointerEvent) => {
+			e.preventDefault();
+			setGhostPos({ x: e.clientX, y: e.clientY });
+		};
+
+		const handlePointerUp = (e: PointerEvent) => {
+			const field = fieldRef.current;
+			if (field) {
+				const rect = field.getBoundingClientRect();
+				const isInsideField =
+					e.clientX >= rect.left &&
+					e.clientX <= rect.right &&
+					e.clientY >= rect.top &&
+					e.clientY <= rect.bottom;
+
+				if (isInsideField) {
+					const x = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+					const y = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+
+					if (paletteDrag.type === 'marker') {
+						handleDropMarker(paletteDrag.id, x, y);
+					} else {
+						handleDropWaymark(paletteDrag.id, x, y);
+					}
+				}
+			}
+
+			setPaletteDrag(null);
+			setGhostPos(null);
+		};
+
+		document.addEventListener('pointermove', handlePointerMove, { passive: false });
+		document.addEventListener('pointerup', handlePointerUp);
+
+		return () => {
+			document.removeEventListener('pointermove', handlePointerMove);
+			document.removeEventListener('pointerup', handlePointerUp);
+		};
+	}, [paletteDrag, handleDropMarker, handleDropWaymark]);
+
+	const ghostColor =
+		paletteDrag?.type === 'marker'
+			? ROLE_COLORS[paletteDrag.id as Role]
+			: paletteDrag
+				? WAYMARK_COLORS[paletteDrag.id as WaymarkLabel]
+				: undefined;
+
+	const isGhostNumber = paletteDrag?.type === 'waymark' && /^[1-4]$/.test(paletteDrag.id);
+
 	return (
 		<div className="flex flex-col gap-4 md:flex-row">
-			<div className="w-full max-w-[400px] flex-shrink-0">
+			<div ref={fieldRef} className="w-full max-w-[400px] flex-shrink-0">
 				<DiagramField
 					data={data}
 					onUpdate={handleUpdate}
@@ -63,8 +138,35 @@ export function DiagramEditor({ initialData, onChange }: DiagramEditorProps) {
 				<DiagramPalette
 					existingMarkers={data.markers.map((m) => m.role)}
 					existingWaymarks={data.waymarks.map((w) => w.label)}
+					onItemPointerDown={handlePalettePointerDown}
 				/>
 			</div>
+
+			{paletteDrag && ghostPos && ghostColor && (
+				<div
+					style={{
+						position: 'fixed',
+						left: ghostPos.x,
+						top: ghostPos.y,
+						transform: 'translate(-50%, -50%)',
+						pointerEvents: 'none',
+						zIndex: 9999,
+						width: paletteDrag.type === 'marker' ? 40 : 32,
+						height: 32,
+						borderRadius: paletteDrag.type === 'marker' ? 9999 : isGhostNumber ? 4 : 9999,
+						backgroundColor: ghostColor,
+						opacity: 0.7,
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						color: '#fff',
+						fontSize: 12,
+						fontWeight: 'bold',
+					}}
+				>
+					{paletteDrag.id}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/diagram/DiagramPalette.tsx
+++ b/src/components/diagram/DiagramPalette.tsx
@@ -12,9 +12,14 @@ import {
 interface DiagramPaletteProps {
 	existingMarkers: string[];
 	existingWaymarks: string[];
+	onItemPointerDown?: (type: 'marker' | 'waymark', id: string, e: React.PointerEvent) => void;
 }
 
-export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPaletteProps) {
+export function DiagramPalette({
+	existingMarkers,
+	existingWaymarks,
+	onItemPointerDown,
+}: DiagramPaletteProps) {
 	return (
 		<div className="flex flex-col gap-4">
 			{/* ロールセクション */}
@@ -35,11 +40,16 @@ export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPal
 									e.dataTransfer.setData('type', 'marker');
 									e.dataTransfer.setData('id', role);
 								}}
+								onPointerDown={(e) => {
+									if (placed || e.pointerType !== 'touch') return;
+									onItemPointerDown?.('marker', role, e);
+								}}
 								className="inline-flex h-8 w-10 items-center justify-center rounded-full text-xs font-bold text-white select-none"
 								style={{
 									backgroundColor: color,
 									opacity: placed ? 0.3 : 1,
 									cursor: placed ? 'default' : 'grab',
+									touchAction: 'none',
 								}}
 							>
 								{role}
@@ -70,6 +80,10 @@ export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPal
 									e.dataTransfer.setData('type', 'waymark');
 									e.dataTransfer.setData('id', label);
 								}}
+								onPointerDown={(e) => {
+									if (placed || e.pointerType !== 'touch') return;
+									onItemPointerDown?.('waymark', label, e);
+								}}
 								className={`inline-flex h-8 w-8 items-center justify-center text-xs font-bold text-white select-none ${
 									isNumber ? 'rounded-sm' : 'rounded-full'
 								}`}
@@ -77,6 +91,7 @@ export function DiagramPalette({ existingMarkers, existingWaymarks }: DiagramPal
 									backgroundColor: color,
 									opacity: placed ? 0.3 : 1,
 									cursor: placed ? 'default' : 'grab',
+									touchAction: 'none',
 								}}
 							>
 								{label}


### PR DESCRIPTION
## Summary
- タッチデバイスでパレットからフィールドへのDnDが動作しない問題を修正
- `pointerType === 'touch'` の場合のみPointer APIベースのカスタムDnDを追加
- ドラッグ中はゴースト要素（半透明アイコン）をポインター位置に表示
- デスクトップの既存HTML5 DnDは変更なし

Closes #89

## 変更内容

### `DiagramPalette.tsx`
- `onItemPointerDown` コールバックpropを追加
- 各パレットアイコンに `onPointerDown` ハンドラーを追加（タッチ時のみ発火）
- `touch-action: none` でタッチドラッグ中のスクロールを防止

### `DiagramEditor.tsx`
- パレットドラッグ状態（`paletteDrag`, `ghostPos`）を管理
- フィールドラッパーdivに `ref` を追加（ドロップ位置判定用）
- `useEffect` で `pointermove`/`pointerup` をdocumentレベルでリッスン
- ゴースト要素を `position: fixed` で描画

## Test plan
- [ ] Chrome DevToolsのデバイスモードでスマホをシミュレートし、パレットからタッチDnDでアイコンを配置できることを確認
- [ ] デスクトップでのマウスDnDが引き続き動作することを確認
- [ ] フィールド上の既存アイコンのドラッグが引き続き動作することを確認
- [ ] 配置済みアイコン（半透明）がドラッグ不可であることを確認
- [ ] フィールド外でドロップした場合にアイコンが配置されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)