### PR TITLE
fix: OAuthコールバックのオープンリダイレクト脆弱性を修正 (#98)

### DIFF
--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -3,7 +3,8 @@ import type { APIRoute } from 'astro';
 export const GET: APIRoute = async (context) => {
 	const { supabase } = context.locals;
 	const code = context.url.searchParams.get('code');
-	const next = context.url.searchParams.get('next') ?? '/';
+	const rawNext = context.url.searchParams.get('next') ?? '/';
+	const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/';
 
 	if (code) {
 		const { error } = await supabase.auth.exchangeCodeForSession(code);


### PR DESCRIPTION
## Summary
- `next` クエリパラメータのバリデーションを追加し、オープンリダイレクト脆弱性を修正
- `/` で始まりかつ `//` で始まらないパスのみ許可（プロトコル相対URLを防止）
- 不正な値の場合は `/` にフォールバック

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)