### PR TITLE
fix: R2画像アップロードのIDOR脆弱性とMIMEタイプ検証不足を修正 (#99, #103)

### DIFF
--- a/src/pages/api/images/[...key].ts
+++ b/src/pages/api/images/[...key].ts
@@ -4,6 +4,28 @@ import { isAllowedContentType } from '../../../lib/images';
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
+function detectMimeType(buffer: ArrayBuffer): string | null {
+	const bytes = new Uint8Array(buffer);
+	if (bytes.length < 4) return null;
+	if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
+	if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47)
+		return 'image/png';
+	if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) return 'image/gif';
+	if (
+		bytes.length >= 12 &&
+		bytes[0] === 0x52 &&
+		bytes[1] === 0x49 &&
+		bytes[2] === 0x46 &&
+		bytes[3] === 0x46 &&
+		bytes[8] === 0x57 &&
+		bytes[9] === 0x45 &&
+		bytes[10] === 0x42 &&
+		bytes[11] === 0x50
+	)
+		return 'image/webp';
+	return null;
+}
+
 export async function PUT(context: APIContext): Promise<Response> {
 	const { currentUser } = context.locals;
 
@@ -14,6 +36,14 @@ export async function PUT(context: APIContext): Promise<Response> {
 	const key = context.params.key;
 	if (!key) {
 		return notFound('Image key is required');
+	}
+
+	const expectedPrefix = `images/${currentUser.id}/`;
+	if (!key.startsWith(expectedPrefix)) {
+		return errorResponse(403, 'FORBIDDEN', 'Cannot upload to this key');
+	}
+	if (key.includes('..') || key.includes('\0')) {
+		return errorResponse(400, 'VALIDATION_ERROR', 'Invalid key');
 	}
 
 	const contentType = context.request.headers.get('content-type') ?? '';
@@ -33,6 +63,15 @@ export async function PUT(context: APIContext): Promise<Response> {
 	const body = await context.request.arrayBuffer();
 	if (body.byteLength > MAX_FILE_SIZE) {
 		return errorResponse(400, 'VALIDATION_ERROR', 'File size must not exceed 5MB');
+	}
+
+	const detectedType = detectMimeType(body);
+	if (!detectedType || detectedType !== contentType) {
+		return errorResponse(
+			400,
+			'VALIDATION_ERROR',
+			'File content does not match declared Content-Type',
+		);
 	}
 
 	const bucket = context.locals.runtime.env.R2_BUCKET;


### PR DESCRIPTION
## Summary

- R2画像PUTエンドポイントのIDOR脆弱性を修正: キーのプレフィックスが `images/{currentUser.id}/` であることを検証し、パストラバーサル攻撃も防止
- 画像アップロード時のMIMEタイプ検証を強化: マジックバイト検出により実際のファイル内容がContent-Typeヘッダーと一致することを検証

Closes #99
Closes #103

## Test plan

- [ ] 自分のユーザーIDプレフィックスで画像アップロードが成功することを確認
- [ ] 他ユーザーのプレフィックスでアップロードすると403エラーになることを確認
- [ ] パストラバーサル(`..`)を含むキーが400エラーになることを確認
- [ ] 正しいContent-Typeヘッダーと正しい画像ファイルでアップロードが成功することを確認
- [ ] Content-Typeヘッダーと実際のファイル内容が不一致の場合に400エラーになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)