### PR TITLE
fix: 下書き記事の漏洩防止とページネーション上限チェックを追加 (#100, #108)

### DIFF
--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -10,6 +10,7 @@ export interface ListArticlesOptions {
 	patch?: string;
 	status?: 'draft' | 'published' | 'archived';
 	sort?: 'newest' | 'popular';
+	authorId?: string;
 	skipCount?: boolean;
 	excludeBody?: boolean;
 }
@@ -108,6 +109,10 @@ export async function listArticles(db: Database, options: ListArticlesOptions = 
 		} else {
 			conditions.push(eq(articles.patch, options.patch));
 		}
+	}
+
+	if (options.authorId) {
+		conditions.push(eq(articles.authorId, options.authorId));
 	}
 
 	if (options.tag) {

--- a/src/pages/api/articles/index.ts
+++ b/src/pages/api/articles/index.ts
@@ -7,8 +7,8 @@ export async function GET(context: APIContext): Promise<Response> {
 	const { db, currentUser } = context.locals;
 	const params = context.url.searchParams;
 
-	const page = Number(params.get('page') ?? '1');
-	const limit = Number(params.get('limit') ?? '20');
+	const page = Math.max(1, Math.min(100, Number(params.get('page') ?? '1') || 1));
+	const limit = Math.max(1, Math.min(100, Number(params.get('limit') ?? '20') || 20));
 	const tag = params.get('tag') ?? undefined;
 	const validStatuses = ['draft', 'published', 'archived'] as const;
 	const rawStatus = params.get('status');
@@ -18,8 +18,15 @@ export async function GET(context: APIContext): Promise<Response> {
 		status = rawStatus as (typeof validStatuses)[number];
 	}
 
-	if (status && !currentUser) {
-		status = 'published';
+	if (status !== 'published' && status !== undefined) {
+		if (!currentUser) {
+			status = 'published';
+		}
+	}
+
+	let authorId: string | undefined;
+	if (status && status !== 'published' && currentUser?.profile?.role !== 'admin') {
+		authorId = currentUser?.id;
 	}
 
 	const validSorts = ['newest', 'popular'] as const;
@@ -31,7 +38,7 @@ export async function GET(context: APIContext): Promise<Response> {
 
 	const patch = params.get('patch') ?? undefined;
 
-	const result = await listArticles(db, { page, limit, tag, patch, status, sort });
+	const result = await listArticles(db, { page, limit, tag, patch, status, sort, authorId });
 
 	return new Response(JSON.stringify(result), {
 		status: 200,

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -6,8 +6,8 @@ export async function GET(context: APIContext): Promise<Response> {
 	const params = context.url.searchParams;
 
 	const query = params.get('q') ?? '';
-	const page = Number.parseInt(params.get('page') ?? '1', 10) || 1;
-	const limit = Number.parseInt(params.get('limit') ?? '20', 10) || 20;
+	const page = Math.max(1, Math.min(100, Number.parseInt(params.get('page') ?? '1', 10) || 1));
+	const limit = Math.max(1, Math.min(100, Number.parseInt(params.get('limit') ?? '20', 10) || 20));
 
 	const result = await searchArticles(db, { query, page, limit });
 


### PR DESCRIPTION
## Summary

- **#100 下書き記事が他ユーザーに漏洩する**: 未認証ユーザーがstatus=draftで記事一覧を取得した場合にpublishedに強制変更。認証済み非adminユーザーにはauthorIdフィルタを追加し、自分の下書きのみ表示されるように修正。
- **#108 ページネーションの上限チェック不足**: articles APIとsearch APIの両方で、pageとlimitを1〜100の範囲にクランプ。

## Changes

- `src/pages/api/articles/index.ts`: アクセス制御ロジック強化、page/limitクランプ追加
- `src/lib/articles.ts`: `ListArticlesOptions`に`authorId`フィールド追加、`listArticles`でauthorIdフィルタ対応
- `src/pages/api/search.ts`: page/limitクランプ追加

Closes #100
Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)