### PR TITLE
fix: DiagramBlockのSVGインジェクション脆弱性を修正 (#105)

### DIFF
--- a/src/components/diagram/renderDiagramSvg.ts
+++ b/src/components/diagram/renderDiagramSvg.ts
@@ -16,7 +16,8 @@ function escapeHtml(str: string): string {
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
 		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
 }
 
 function toSvgX(normalizedX: number): number {

--- a/src/components/editor/extensions/DiagramBlock.tsx
+++ b/src/components/editor/extensions/DiagramBlock.tsx
@@ -1,6 +1,7 @@
 import CodeBlock from '@tiptap/extension-code-block';
 import type { NodeViewProps } from '@tiptap/react';
 import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
+import DOMPurify from 'dompurify';
 import { Pencil, Trash2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { DiagramModal } from '@/components/diagram/DiagramModal';
@@ -116,8 +117,15 @@ function DiagramNodeView({ node, editor, getPos, selected }: NodeViewProps) {
 					</div>
 				</div>
 				<div className="diagram-preview-body">
-					{/* biome-ignore lint/security/noDangerouslySetInnerHtml: SVG is generated from validated DiagramData via parseDiagramJson + renderDiagramSvg; input is JSON-parsed and type-checked, not raw user HTML */}
-					<div className="diagram-container" dangerouslySetInnerHTML={{ __html: svgHtml }} />
+					<div
+						className="diagram-container"
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: SVG is sanitized with DOMPurify before injection
+						dangerouslySetInnerHTML={{
+							__html: DOMPurify.sanitize(svgHtml, {
+								USE_PROFILES: { svg: true, svgFilters: true },
+							}),
+						}}
+					/>
 				</div>
 			</div>
 			{editing && (


### PR DESCRIPTION
## Summary
- `escapeHtml` 関数にシングルクォートのエスケープ (`'` → `&#39;`) を追加
- `DiagramBlock.tsx` で `dangerouslySetInnerHTML` に渡す SVG を DOMPurify でサニタイズするよう変更

Closes #105

## Test plan
- [ ] DiagramBlock が正常にSVGを描画することを確認
- [ ] シングルクォートを含むラベルが正しくエスケープされることを確認
- [ ] 悪意のあるSVGコンテンツがDOMPurifyにより除去されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)