### PR TITLE
fix: アバターURLを信頼できるドメインのみに制限 (#107)

### DIFF
--- a/src/pages/api/auth/setup-profile.ts
+++ b/src/pages/api/auth/setup-profile.ts
@@ -39,12 +39,14 @@ export const POST: APIRoute = async (context) => {
 		return context.redirect('/onboarding?error=username_taken');
 	}
 
+	const TRUSTED_AVATAR_DOMAINS = ['lh3.googleusercontent.com', 'avatars.githubusercontent.com'];
+
 	const rawAvatarUrl = formData.get('avatarUrl')?.toString()?.trim() || null;
 	let customAvatarUrl: string | null = null;
 	if (rawAvatarUrl) {
 		try {
 			const parsed = new URL(rawAvatarUrl);
-			if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+			if (parsed.protocol === 'https:' && TRUSTED_AVATAR_DOMAINS.includes(parsed.hostname)) {
 				customAvatarUrl = rawAvatarUrl;
 			}
 		} catch {

--- a/src/pages/api/auth/update-profile.ts
+++ b/src/pages/api/auth/update-profile.ts
@@ -47,19 +47,22 @@ export async function POST(context: APIContext): Promise<Response> {
 		}
 	}
 
+	const TRUSTED_AVATAR_DOMAINS = ['lh3.googleusercontent.com', 'avatars.githubusercontent.com'];
+
 	if (obj.avatarUrl !== undefined) {
 		if (typeof obj.avatarUrl !== 'string') {
 			errors.avatarUrl = ['avatarUrl must be a string'];
 		} else {
 			try {
 				const parsed = new URL(obj.avatarUrl);
-				if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-					errors.avatarUrl = ['avatarUrl must be an HTTP(S) URL'];
+				if (parsed.protocol !== 'https:') {
+					errors.avatarUrl = ['avatarUrl must be an HTTPS URL'];
+				} else if (!TRUSTED_AVATAR_DOMAINS.includes(parsed.hostname)) {
+					errors.avatarUrl = ['avatarUrl domain is not allowed'];
 				} else {
 					updates.avatarUrl = obj.avatarUrl;
 				}
 			} catch {
-				// 相対パス（/api/images/... 等）も許可
 				if (obj.avatarUrl.startsWith('/api/images/')) {
 					updates.avatarUrl = obj.avatarUrl;
 				} else {


### PR DESCRIPTION
## Summary
- アバターURLのバリデーションを強化し、信頼できるドメイン（`lh3.googleusercontent.com`, `avatars.githubusercontent.com`）のHTTPS URLのみ許可するように変更
- `setup-profile.ts` と `update-profile.ts` の両方で同一のドメインホワイトリストを適用
- HTTP URLの受け入れを廃止（HTTPSのみ許可）

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)