### PR TITLE
fix: 通報一覧の記事リンクをslugベースに修正 (#126)

### DIFF
--- a/src/components/admin/ReportManagement.tsx
+++ b/src/components/admin/ReportManagement.tsx
@@ -6,6 +6,8 @@ interface Report {
 	description: string | null;
 	targetType: 'article' | 'comment';
 	targetId: string;
+	targetSlug: string | null;
+	targetTitle: string | null;
 	reporterId: string;
 	status: 'pending' | 'resolved' | 'dismissed';
 	resolvedBy: string | null;
@@ -137,12 +139,18 @@ export default function ReportManagement() {
 		});
 	}
 
-	function getTargetLink(targetType: Report['targetType'], targetId: string): string {
-		return targetType === 'article' ? `/articles/${targetId}` : '#';
+	function getTargetLink(report: Report): string {
+		if (report.targetType === 'article' && report.targetSlug) {
+			return `/articles/${report.targetSlug}`;
+		}
+		return '#';
 	}
 
-	function getTargetLabel(targetType: Report['targetType']): string {
-		return targetType === 'article' ? '記事' : 'コメント';
+	function getTargetLabel(report: Report): string {
+		if (report.targetType === 'article') {
+			return report.targetTitle ?? `記事 (${report.targetId.slice(0, 8)})`;
+		}
+		return 'コメント';
 	}
 
 	if (isLoading) {
@@ -231,10 +239,10 @@ export default function ReportManagement() {
 											</td>
 											<td className="px-4 py-3">
 												<a
-													href={getTargetLink(report.targetType, report.targetId)}
+													href={getTargetLink(report)}
 													className="text-sm text-primary hover:underline"
 												>
-													{getTargetLabel(report.targetType)} ({report.targetId.slice(0, 8)})
+													{getTargetLabel(report)}
 												</a>
 											</td>
 											<td className="px-4 py-3">
@@ -300,10 +308,10 @@ export default function ReportManagement() {
 									)}
 									<div className="flex items-center justify-between">
 										<a
-											href={getTargetLink(report.targetType, report.targetId)}
+											href={getTargetLink(report)}
 											className="text-sm text-primary hover:underline"
 										>
-											{getTargetLabel(report.targetType)} ({report.targetId.slice(0, 8)})
+											{getTargetLabel(report)}
 										</a>
 										<span className="text-xs text-muted-foreground">
 											{formatDate(report.createdAt)}

--- a/src/lib/reports.ts
+++ b/src/lib/reports.ts
@@ -1,6 +1,6 @@
-import { and, count, desc, eq } from 'drizzle-orm';
+import { and, count, desc, eq, sql } from 'drizzle-orm';
 import type { Database } from '../db';
-import { reports } from '../db/schema';
+import { articles, reports } from '../db/schema';
 
 export interface CreateReportData {
 	reason: 'spam' | 'inappropriate' | 'misleading' | 'other';
@@ -62,8 +62,22 @@ export async function listReports(db: Database, options: ListReportsOptions = {}
 	const totalResult = await db.select({ total: count() }).from(reports).where(where);
 
 	const rows = await db
-		.select()
+		.select({
+			id: reports.id,
+			reason: reports.reason,
+			description: reports.description,
+			targetType: reports.targetType,
+			targetId: reports.targetId,
+			reporterId: reports.reporterId,
+			status: reports.status,
+			resolvedBy: reports.resolvedBy,
+			resolvedAt: reports.resolvedAt,
+			createdAt: reports.createdAt,
+			targetSlug: sql<string | null>`${articles.slug}`,
+			targetTitle: sql<string | null>`${articles.title}`,
+		})
 		.from(reports)
+		.leftJoin(articles, and(eq(reports.targetType, 'article'), eq(reports.targetId, articles.id)))
 		.where(where)
 		.orderBy(desc(reports.createdAt))
 		.limit(limit)


### PR DESCRIPTION
## Summary
- 通報一覧の記事リンクが UUID ベース (`/articles/${targetId}`) で 404 になるバグを修正
- `listReports` で `articles` テーブルを LEFT JOIN し、`slug` と `title` を取得
- フロントで slug ベースのリンク (`/articles/${slug}`) と記事タイトルを表示するように変更

Closes #126

## Test plan
- [ ] 通報一覧で記事リンクをクリックすると該当記事ページに遷移する
- [ ] 記事タイトルがリンクテキストとして表示される
- [ ] 削除済み記事の通報はフォールバック表示（UUID先頭8文字）になる
- [ ] コメント通報のリンクには影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)