### PR TITLE
feat: エディタUI改善 (#131, #132, #133, #134, #135)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@supabase/supabase-js": "^2.98.0",
 		"@tailwindcss/vite": "^4.2.1",
 		"@tiptap/extension-code-block": "^3.20.0",
+		"@tiptap/extension-image": "^3.20.0",
 		"@tiptap/extension-link": "^3.20.0",
 		"@tiptap/extension-placeholder": "^3.20.0",
 		"@tiptap/pm": "^3.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tiptap/extension-code-block':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
+      '@tiptap/extension-image':
+        specifier: ^3.20.0
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extension-link':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
@@ -2546,6 +2549,11 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.20.0
       '@tiptap/pm': ^3.20.0
+
+  '@tiptap/extension-image@3.20.0':
+    resolution: {integrity: sha512-0t7HYncV0kYEQS79NFczxdlZoZ8zu8X4VavDqt+mbSAUKRq3gCvgtZ5Zyd778sNmtmbz3arxkEYMIVou2swD0g==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.0
 
   '@tiptap/extension-italic@3.20.0':
     resolution: {integrity: sha512-/DhnKQF8yN8RxtuL8abZ28wd5281EaGoE2Oha35zXSOF1vNYnbyt8Ymkv/7u1BcWEWTvRPgaju0YCGXisPRLYw==}
@@ -7608,6 +7616,10 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
+
+  '@tiptap/extension-image@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
+    dependencies:
+      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-italic@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
     dependencies:

--- a/src/components/editor/ArticleEditor.tsx
+++ b/src/components/editor/ArticleEditor.tsx
@@ -227,6 +227,7 @@ export function ArticleEditor({ mode, tags, article }: ArticleEditorProps) {
 							content={body}
 							onChange={setBody}
 							onInsertMacro={handleInsertMacro}
+							onOpenDiagram={() => setIsDiagramOpen(true)}
 						/>
 						{errors.body && <p className="text-sm text-destructive mt-1">{errors.body[0]}</p>}
 						<p className="text-xs text-muted-foreground text-right mt-1">
@@ -292,16 +293,19 @@ export function ArticleEditor({ mode, tags, article }: ArticleEditorProps) {
 				)}
 			</div>
 
-			{/* Diagram button */}
-			<Button type="button" variant="outline" onClick={() => setIsDiagramOpen(true)}>
-				<Grid2x2 className="h-4 w-4" />
-				散開図
-			</Button>
-
-			{/* Image uploader & Macro insert (Markdown mode only) */}
+			{/* Diagram, Image uploader & Macro insert (Markdown mode only) */}
 			{editorMode === 'markdown' && (
 				<div className="space-y-3">
 					<div className="flex gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={() => setIsDiagramOpen(true)}
+						>
+							<Grid2x2 className="h-4 w-4 mr-1" />
+							散開図
+						</Button>
 						<Button
 							type="button"
 							variant="outline"

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -3,6 +3,7 @@ import {
 	Bold,
 	Code,
 	Gamepad2,
+	Grid2x2,
 	Heading1,
 	Heading2,
 	Heading3,
@@ -14,19 +15,21 @@ import {
 	Redo,
 	Undo,
 } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 
 interface EditorToolbarProps {
 	editor: Editor;
 	onInsertMacro: (macro: string) => void;
+	onOpenDiagram?: () => void;
 }
 
-export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
+export function EditorToolbar({ editor, onInsertMacro, onOpenDiagram }: EditorToolbarProps) {
 	const [linkUrl, setLinkUrl] = useState('');
 	const [showLinkInput, setShowLinkInput] = useState(false);
 	const [showMacroDialog, setShowMacroDialog] = useState(false);
 	const [macroText, setMacroText] = useState('');
+	const savedSelectionRef = useRef<{ from: number; to: number } | null>(null);
 
 	const macroLineCount = macroText ? macroText.split('\n').length : 0;
 
@@ -49,20 +52,29 @@ export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 			editor.chain().focus().unsetLink().run();
 			return;
 		}
+		const { from, to } = editor.state.selection;
+		savedSelectionRef.current = { from, to };
 		setShowLinkInput(true);
 	}, [editor]);
 
 	const applyLink = useCallback(() => {
 		if (linkUrl && /^(https?:\/\/|mailto:)/i.test(linkUrl)) {
-			editor.chain().focus().setLink({ href: linkUrl }).run();
+			const chain = editor.chain().focus();
+			if (savedSelectionRef.current) {
+				const { from, to } = savedSelectionRef.current;
+				chain.setTextSelection({ from, to });
+			}
+			chain.setLink({ href: linkUrl }).run();
 		}
 		setLinkUrl('');
 		setShowLinkInput(false);
+		savedSelectionRef.current = null;
 	}, [editor, linkUrl]);
 
 	const cancelLink = useCallback(() => {
 		setLinkUrl('');
 		setShowLinkInput(false);
+		savedSelectionRef.current = null;
 		editor.chain().focus().run();
 	}, [editor]);
 
@@ -71,21 +83,21 @@ export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
 				active={editor.isActive('heading', { level: 1 })}
-				title="見出し1"
+				tooltip="見出し1"
 			>
 				<Heading1 className="h-4 w-4" />
 			</ToolbarButton>
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
 				active={editor.isActive('heading', { level: 2 })}
-				title="見出し2"
+				tooltip="見出し2"
 			>
 				<Heading2 className="h-4 w-4" />
 			</ToolbarButton>
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
 				active={editor.isActive('heading', { level: 3 })}
-				title="見出し3"
+				tooltip="見出し3"
 			>
 				<Heading3 className="h-4 w-4" />
 			</ToolbarButton>
@@ -95,14 +107,14 @@ export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleBold().run()}
 				active={editor.isActive('bold')}
-				title="太字"
+				tooltip="太字"
 			>
 				<Bold className="h-4 w-4" />
 			</ToolbarButton>
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleItalic().run()}
 				active={editor.isActive('italic')}
-				title="斜体"
+				tooltip="斜体"
 			>
 				<Italic className="h-4 w-4" />
 			</ToolbarButton>
@@ -112,14 +124,14 @@ export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleBulletList().run()}
 				active={editor.isActive('bulletList')}
-				title="箇条書き"
+				tooltip="箇条書き"
 			>
 				<List className="h-4 w-4" />
 			</ToolbarButton>
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleOrderedList().run()}
 				active={editor.isActive('orderedList')}
-				title="番号付きリスト"
+				tooltip="番号付きリスト"
 			>
 				<ListOrdered className="h-4 w-4" />
 			</ToolbarButton>
@@ -129,26 +141,35 @@ export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleBlockquote().run()}
 				active={editor.isActive('blockquote')}
-				title="引用"
+				tooltip="引用"
 			>
 				<Quote className="h-4 w-4" />
 			</ToolbarButton>
 			<ToolbarButton
 				onClick={() => editor.chain().focus().toggleCodeBlock().run()}
 				active={editor.isActive('codeBlock')}
-				title="コードブロック"
+				tooltip="コードブロック"
 			>
 				<Code className="h-4 w-4" />
 			</ToolbarButton>
 
 			<ToolbarSeparator />
 
-			<ToolbarButton onClick={() => setShowMacroDialog(true)} active={false} title="マクロ挿入">
+			<ToolbarButton
+				onClick={() => setShowMacroDialog(true)}
+				active={false}
+				tooltip="FF14マクロを挿入"
+			>
 				<Gamepad2 className="h-4 w-4" />
 			</ToolbarButton>
-			<ToolbarButton onClick={toggleLink} active={editor.isActive('link')} title="リンク">
+			<ToolbarButton onClick={toggleLink} active={editor.isActive('link')} tooltip="リンクを挿入">
 				<Link className="h-4 w-4" />
 			</ToolbarButton>
+			{onOpenDiagram && (
+				<ToolbarButton onClick={onOpenDiagram} active={false} tooltip="散開図を作成">
+					<Grid2x2 className="h-4 w-4" />
+				</ToolbarButton>
+			)}
 
 			<ToolbarSeparator />
 
@@ -156,7 +177,7 @@ export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 				onClick={() => editor.chain().focus().undo().run()}
 				active={false}
 				disabled={!editor.can().undo()}
-				title="元に戻す"
+				tooltip="元に戻す"
 			>
 				<Undo className="h-4 w-4" />
 			</ToolbarButton>
@@ -164,7 +185,7 @@ export function EditorToolbar({ editor, onInsertMacro }: EditorToolbarProps) {
 				onClick={() => editor.chain().focus().redo().run()}
 				active={false}
 				disabled={!editor.can().redo()}
-				title="やり直す"
+				tooltip="やり直す"
 			>
 				<Redo className="h-4 w-4" />
 			</ToolbarButton>
@@ -237,29 +258,33 @@ function ToolbarButton({
 	onClick,
 	active,
 	disabled,
-	title,
+	tooltip,
 	children,
 }: {
 	onClick: () => void;
 	active: boolean;
 	disabled?: boolean;
-	title: string;
+	tooltip: string;
 	children: React.ReactNode;
 }) {
 	return (
-		<button
-			type="button"
-			onClick={onClick}
-			disabled={disabled}
-			title={title}
-			className={`inline-flex items-center justify-center rounded p-1.5 text-sm transition-colors disabled:opacity-40 ${
-				active
-					? 'bg-secondary text-foreground'
-					: 'text-muted-foreground hover:bg-secondary hover:text-foreground'
-			}`}
-		>
-			{children}
-		</button>
+		<div className="group relative">
+			<button
+				type="button"
+				onClick={onClick}
+				disabled={disabled}
+				className={`inline-flex items-center justify-center rounded p-1.5 text-sm transition-colors disabled:opacity-40 ${
+					active
+						? 'bg-secondary text-foreground'
+						: 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+				}`}
+			>
+				{children}
+			</button>
+			<span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md border border-border opacity-0 transition-opacity group-hover:opacity-100">
+				{tooltip}
+			</span>
+		</div>
 	);
 }
 

--- a/src/components/editor/MacroBlockNodeView.tsx
+++ b/src/components/editor/MacroBlockNodeView.tsx
@@ -51,7 +51,7 @@ function MacroPreview({ node, editor, getPos }: Pick<NodeViewProps, 'node' | 'ed
 			.chain()
 			.command(({ tr, dispatch }) => {
 				if (dispatch) {
-					const newNode = editor.schema.nodes.codeBlock.create(
+					const newNode = editor.schema.nodes.macroCodeBlock.create(
 						{ language: 'ffxiv-macro' },
 						trimmed ? editor.schema.text(trimmed) : undefined,
 					);

--- a/src/components/editor/MacroCodeBlock.ts
+++ b/src/components/editor/MacroCodeBlock.ts
@@ -3,6 +3,35 @@ import { ReactNodeViewRenderer } from '@tiptap/react';
 import { MacroBlockNodeView } from './MacroBlockNodeView';
 
 export const MacroCodeBlock = CodeBlock.extend({
+	name: 'macroCodeBlock',
+
+	parseHTML() {
+		return [
+			{
+				tag: 'pre',
+				preserveWhitespace: 'full' as const,
+				getAttrs: (node) => {
+					const el = node as HTMLElement;
+					const code = el.querySelector('code');
+					if (!code?.classList.contains('language-ffxiv-macro')) return false;
+					return { language: 'ffxiv-macro' };
+				},
+				priority: 200,
+			},
+		];
+	},
+
+	addStorage() {
+		return {
+			markdown: {
+				serialize(state: { write: (text: string) => void }, node: { textContent: string }) {
+					state.write(`\`\`\`ffxiv-macro\n${node.textContent}\n\`\`\``);
+				},
+				parse: {},
+			},
+		};
+	},
+
 	addNodeView() {
 		return ReactNodeViewRenderer(MacroBlockNodeView);
 	},

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -1,31 +1,153 @@
+import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
+import type { EditorView } from '@tiptap/pm/view';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Markdown } from 'tiptap-markdown';
 import { EditorToolbar } from './EditorToolbar';
 import { DiagramBlock } from './extensions/DiagramBlock';
 import { MacroCodeBlock } from './MacroCodeBlock';
 
+const ALLOWED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+
 interface RichTextEditorProps {
 	content: string;
 	onChange: (markdown: string) => void;
 	onInsertMacro?: (macro: string) => void;
+	onOpenDiagram?: () => void;
 }
 
-export function RichTextEditor({ content, onChange, onInsertMacro }: RichTextEditorProps) {
+async function uploadImage(file: File): Promise<{ imageUrl: string; alt: string } | null> {
+	if (!ALLOWED_IMAGE_TYPES.has(file.type)) return null;
+	if (file.size > MAX_IMAGE_SIZE) return null;
+
+	const metaRes = await fetch('/api/images/upload', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			filename: file.name,
+			contentType: file.type,
+			size: file.size,
+		}),
+	});
+	if (!metaRes.ok) return null;
+
+	const { uploadUrl, imageUrl } = await metaRes.json();
+
+	const putRes = await fetch(uploadUrl, {
+		method: 'PUT',
+		headers: { 'Content-Type': file.type },
+		body: file,
+	});
+	if (!putRes.ok) return null;
+
+	const alt = file.name.replace(/[[\]()]/g, '');
+	return { imageUrl, alt };
+}
+
+export function RichTextEditor({
+	content,
+	onChange,
+	onInsertMacro,
+	onOpenDiagram,
+}: RichTextEditorProps) {
+	const [uploadError, setUploadError] = useState<string | null>(null);
+	const isUploadingRef = useRef(false);
+
+	const handleImageDrop = useCallback(
+		(view: EditorView, event: DragEvent, _slice: unknown, moved: boolean): boolean => {
+			if (moved || !event.dataTransfer?.files?.length) return false;
+
+			const file = event.dataTransfer.files[0];
+			if (!file || !ALLOWED_IMAGE_TYPES.has(file.type)) return false;
+
+			event.preventDefault();
+			if (isUploadingRef.current) return true;
+			isUploadingRef.current = true;
+			setUploadError(null);
+
+			uploadImage(file)
+				.then((result) => {
+					if (result) {
+						const { state } = view;
+						const pos = view.posAtCoords({ left: event.clientX, top: event.clientY });
+						const insertPos = pos?.pos ?? state.selection.from;
+						const node = state.schema.nodes.image.create({ src: result.imageUrl, alt: result.alt });
+						const tr = state.tr.insert(insertPos, node);
+						view.dispatch(tr);
+					} else {
+						setUploadError('画像のアップロードに失敗しました');
+					}
+				})
+				.catch(() => {
+					setUploadError('画像のアップロードに失敗しました');
+				})
+				.finally(() => {
+					isUploadingRef.current = false;
+				});
+
+			return true;
+		},
+		[],
+	);
+
+	const handleImagePaste = useCallback((view: EditorView, event: ClipboardEvent): boolean => {
+		const items = event.clipboardData?.items;
+		if (!items) return false;
+
+		for (const item of items) {
+			if (item.type.startsWith('image/')) {
+				const file = item.getAsFile();
+				if (!file) continue;
+
+				event.preventDefault();
+				if (isUploadingRef.current) return true;
+				isUploadingRef.current = true;
+				setUploadError(null);
+
+				uploadImage(file)
+					.then((result) => {
+						if (result) {
+							const node = view.state.schema.nodes.image.create({
+								src: result.imageUrl,
+								alt: result.alt,
+							});
+							const tr = view.state.tr.replaceSelectionWith(node);
+							view.dispatch(tr);
+						} else {
+							setUploadError('画像のアップロードに失敗しました');
+						}
+					})
+					.catch(() => {
+						setUploadError('画像のアップロードに失敗しました');
+					})
+					.finally(() => {
+						isUploadingRef.current = false;
+					});
+
+				return true;
+			}
+		}
+		return false;
+	}, []);
+
 	const editor = useEditor({
 		extensions: [
 			StarterKit.configure({
 				heading: { levels: [1, 2, 3] },
-				codeBlock: false,
 			}),
 			MacroCodeBlock,
 			DiagramBlock,
 			Link.configure({
 				openOnClick: false,
 				HTMLAttributes: { rel: 'noopener noreferrer nofollow', target: '_blank' },
+			}),
+			Image.configure({
+				inline: false,
+				allowBase64: false,
 			}),
 			Placeholder.configure({
 				placeholder: 'ビジュアルモードで記事を書く...',
@@ -46,6 +168,8 @@ export function RichTextEditor({ content, onChange, onInsertMacro }: RichTextEdi
 			attributes: {
 				class: 'tiptap-editor outline-none',
 			},
+			handleDrop: handleImageDrop,
+			handlePaste: handleImagePaste,
 		},
 	});
 
@@ -55,7 +179,6 @@ export function RichTextEditor({ content, onChange, onInsertMacro }: RichTextEdi
 			if (onInsertMacro) {
 				onInsertMacro(macro);
 			} else {
-				// Fallback: append macro block via Markdown storage
 				const storage = editor.storage as unknown as Record<string, { getMarkdown: () => string }>;
 				const currentMd = storage.markdown.getMarkdown();
 				const macroBlock = `\n\n\`\`\`ffxiv-macro\n${macro}\n\`\`\`\n`;
@@ -77,10 +200,15 @@ export function RichTextEditor({ content, onChange, onInsertMacro }: RichTextEdi
 
 	return (
 		<div className="flex flex-col">
-			<EditorToolbar editor={editor} onInsertMacro={handleInsertMacro} />
+			<EditorToolbar
+				editor={editor}
+				onInsertMacro={handleInsertMacro}
+				onOpenDiagram={onOpenDiagram}
+			/>
 			<div className="h-[500px] overflow-y-auto rounded-b-md border border-input px-4 py-3 dark:bg-input/30">
 				<EditorContent editor={editor} />
 			</div>
+			{uploadError && <p className="text-sm text-destructive mt-1">{uploadError}</p>}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

エディタのUI/UX改善を5件まとめて対応。

- **ツールチップ追加 (#131)**: ToolbarButton をCSSベースのスタイル付きツールチップに改善。全ボタン（独自項目含む）にホバー時ツールチップ表示
- **散会図ボタン移動 (#132)**: エディタ下部にあった散会図ボタンをツールバー内に移動（ビジュアルモード時）。Markdownモードでは従来通りボタンとして表示
- **画像D&D対応 (#133)**: `@tiptap/extension-image` を追加し、ビジュアルエディタへの画像ドラッグ&ドロップおよびペースト挿入に対応。ドロップ位置にカーソル挿入
- **コードブロック修正 (#134)**: `MacroCodeBlock` に `name: 'macroCodeBlock'` と `parseHTML` を追加し、通常の `codeBlock`（StarterKit）と分離。コードブロックボタンで通常コードブロックが正しく挿入されるように
- **リンク挿入修正 (#135)**: リンク入力UI表示時にエディタの選択範囲が失われる問題を修正。`useRef` で選択範囲を保存し、リンク適用時に復元

Closes #131
Closes #132
Closes #133
Closes #134
Closes #135

## Test plan
- [ ] ツールバーの各ボタンをホバーしてツールチップが表示されることを確認
- [ ] ビジュアルモードでツールバーの散会図ボタンから散会図を作成できることを確認
- [ ] Markdownモードでも散会図ボタンが表示され動作することを確認
- [ ] ビジュアルエディタに画像をD&Dして挿入されることを確認
- [ ] ビジュアルエディタに画像をペーストして挿入されることを確認
- [ ] コードブロックボタンで通常のコードブロックが挿入されることを確認
- [ ] マクロ挿入ボタンでFFXIVマクロブロックが正しく挿入されることを確認
- [ ] テキスト選択後にリンクボタン→URL入力→OKでリンクが正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)