### PR TITLE
feat: タグセレクターにタグ申請への案内文言を追加 (#155)

### DIFF
--- a/src/components/editor/TagSelector.tsx
+++ b/src/components/editor/TagSelector.tsx
@@ -64,6 +64,9 @@ export function TagSelector({ tags, selectedIds, onChange, categories }: TagSele
 					</div>
 				</div>
 			))}
+			<p className="text-xs text-muted-foreground">
+				ここにないタグが欲しい場合は、右上のメニューからタグ申請できます
+			</p>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- 編集ページのタグセレクター下部に「ここにないタグが欲しい場合は、右上のメニューからタグ申請できます」という案内文言を追加

Closes #155

## Test plan
- [ ] 記事編集ページでタグセレクターの下に案内文言が表示されることを確認
- [ ] 文言のスタイルが他のヘルプテキストと統一されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)