### PR TITLE
feat: エディタツールバーのマクロ・散開図ボタンを目立たせる (#157)

### DIFF
--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -155,21 +155,32 @@ export function EditorToolbar({ editor, onInsertMacro, onOpenDiagram }: EditorTo
 
 			<ToolbarSeparator />
 
-			<ToolbarButton
-				onClick={() => setShowMacroDialog(true)}
-				active={false}
-				tooltip="FF14マクロを挿入"
-			>
-				<Gamepad2 className="h-4 w-4" />
-			</ToolbarButton>
 			<ToolbarButton onClick={toggleLink} active={editor.isActive('link')} tooltip="リンクを挿入">
 				<Link className="h-4 w-4" />
 			</ToolbarButton>
-			{onOpenDiagram && (
-				<ToolbarButton onClick={onOpenDiagram} active={false} tooltip="散開図を作成">
-					<Grid2x2 className="h-4 w-4" />
-				</ToolbarButton>
-			)}
+
+			<ToolbarSeparator />
+
+			<div className="flex items-center gap-1 ml-0.5">
+				<button
+					type="button"
+					onClick={() => setShowMacroDialog(true)}
+					className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+				>
+					<Gamepad2 className="h-3.5 w-3.5" />
+					<span className="hidden sm:inline">マクロ</span>
+				</button>
+				{onOpenDiagram && (
+					<button
+						type="button"
+						onClick={onOpenDiagram}
+						className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+					>
+						<Grid2x2 className="h-3.5 w-3.5" />
+						<span className="hidden sm:inline">散開図</span>
+					</button>
+				)}
+			</div>
 
 			<ToolbarSeparator />
 


### PR DESCRIPTION
## Summary
- マクロ挿入・散開図ボタンをテキストラベル付きのアクセントカラースタイルに変更
- 標準書式ボタン（太字、リスト等）からセパレーターで視覚的に分離
- モバイルではアイコンのみ、デスクトップではラベルも表示するレスポンシブ対応

Closes #157

## Test plan
- [ ] ビジュアルエディタのツールバーでマクロ・散開図ボタンが他のボタンと区別できること
- [ ] マクロボタンクリックでマクロ挿入ダイアログが開くこと
- [ ] 散開図ボタンクリックで散開図モーダルが開くこと
- [ ] モバイル幅でアイコンのみ表示されること
- [ ] デスクトップ幅でテキストラベルも表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)