### PR TITLE
chore: エディタツールバーからコードブロック挿入ボタンを削除

### DIFF
--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -1,7 +1,6 @@
 import type { Editor } from '@tiptap/react';
 import {
 	Bold,
-	Code,
 	Gamepad2,
 	Grid2x2,
 	Heading1,
@@ -145,14 +144,6 @@ export function EditorToolbar({ editor, onInsertMacro, onOpenDiagram }: EditorTo
 			>
 				<Quote className="h-4 w-4" />
 			</ToolbarButton>
-			<ToolbarButton
-				onClick={() => editor.chain().focus().toggleCodeBlock().run()}
-				active={editor.isActive('codeBlock')}
-				tooltip="コードブロック"
-			>
-				<Code className="h-4 w-4" />
-			</ToolbarButton>
-
 			<ToolbarSeparator />
 
 			<ToolbarButton


### PR DESCRIPTION
## Summary
- ビジュアルエディタのツールバーからコードブロック挿入ボタンを削除
- 未使用になった `Code` アイコンのimportも削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)