### PR TITLE
fix: トップページのXIVPediaテキストを削除しロゴに統一

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,10 +21,7 @@ const categorySlugs = categories.map((c) => c.slug);
 
 <Layout title="トップ" description="XIVPedia - ユーザー投稿型のFF14攻略サイト">
 	<section class="py-12 text-center">
-		<img src="/logo.png" alt="XIVPedia" class="mx-auto mb-4 h-32 w-32 sm:h-40 sm:w-40" />
-		<h1 class="text-4xl font-bold text-foreground sm:text-5xl">
-			XIVP<span class="text-primary">e</span>dia
-		</h1>
+		<img src="/logo.png" alt="XIVPedia" class="mx-auto h-48 w-48 sm:h-56 sm:w-56" />
 		<p class="mt-4 text-lg text-muted-foreground max-w-xl mx-auto">
 			ユーザー投稿型のFF14攻略サイト。<br />
 			攻略情報を共有して、みんなで冒険をもっと楽しもう。


### PR DESCRIPTION
## Summary
- トップページのh1テキスト「XIVPedia」を削除（ロゴ画像にテキストが含まれているため重複）
- ロゴサイズを少し大きく調整（h-32→h-48, sm:h-40→sm:h-56）

## Test plan
- [ ] トップページでロゴのみ表示され、テキストの重複がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)