### PR TITLE
feat: カスタム 404 / 500 エラーページを作成 (#145)

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,22 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="ページが見つかりません" description="お探しのページは見つかりませんでした">
+	<section class="py-20 text-center flex flex-col items-center justify-center min-h-[60vh]">
+		<p class="text-8xl font-bold text-muted-foreground/30 select-none">404</p>
+		<h1 class="mt-6 text-3xl font-bold text-foreground sm:text-4xl">
+			ページが見つかりません
+		</h1>
+		<p class="mt-4 text-lg text-muted-foreground max-w-md mx-auto">
+			お探しのページは移動または削除された可能性があります。<br />
+			URLが正しいかご確認ください。
+		</p>
+		<a
+			href="/"
+			class="mt-8 inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+		>
+			トップページへ戻る
+		</a>
+	</section>
+</Layout>

--- a/src/pages/500.astro
+++ b/src/pages/500.astro
@@ -1,0 +1,22 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="サーバーエラー" description="サーバーエラーが発生しました">
+	<section class="py-20 text-center flex flex-col items-center justify-center min-h-[60vh]">
+		<p class="text-8xl font-bold text-muted-foreground/30 select-none">500</p>
+		<h1 class="mt-6 text-3xl font-bold text-foreground sm:text-4xl">
+			サーバーエラーが発生しました
+		</h1>
+		<p class="mt-4 text-lg text-muted-foreground max-w-md mx-auto">
+			申し訳ありません。サーバー側で問題が発生しました。<br />
+			しばらく時間をおいてから再度お試しください。
+		</p>
+		<a
+			href="/"
+			class="mt-8 inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+		>
+			トップページへ戻る
+		</a>
+	</section>
+</Layout>


### PR DESCRIPTION
## Summary
- 404 Not Found ページ (`src/pages/404.astro`) を作成
- 500 Internal Server Error ページ (`src/pages/500.astro`) を作成
- サイト全体のダークテーマに統一したデザイン
- トップページへのリンクを設置

Closes #145

## Test plan
- [ ] 存在しないURLにアクセスして404ページが表示されることを確認
- [ ] サーバーエラー発生時に500ページが表示されることを確認
- [ ] トップページへのリンクが正常に機能することを確認
- [ ] モバイル/デスクトップ両方でレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)