### PR TITLE
fix: タグセレクターを「さらに表示」モーダルUIに変更 (#171)

### DIFF
--- a/src/components/editor/TagSelector.tsx
+++ b/src/components/editor/TagSelector.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Label } from '@/components/ui/label';
 import type { TagInfo } from '@/lib/tags';
 
@@ -14,7 +15,7 @@ interface TagSelectorProps {
 	categories?: CategoryLabel[];
 }
 
-const DROPDOWN_THRESHOLD = 6;
+const VISIBLE_COUNT = 5;
 
 export function TagSelector({ tags, selectedIds, onChange, categories }: TagSelectorProps) {
 	const categoryLabels = new Map(categories?.map((c) => [c.slug, c.name]) ?? []);
@@ -25,19 +26,16 @@ export function TagSelector({ tags, selectedIds, onChange, categories }: TagSele
 		grouped.set(tag.category, list);
 	}
 
-	function handleToggle(tagId: string) {
-		if (selectedIds.includes(tagId)) {
-			onChange(selectedIds.filter((id) => id !== tagId));
-		} else if (selectedIds.length < 10) {
-			onChange([...selectedIds, tagId]);
-		}
-	}
-
-	function handleDropdownAdd(tagId: string) {
-		if (tagId && !selectedIds.includes(tagId) && selectedIds.length < 10) {
-			onChange([...selectedIds, tagId]);
-		}
-	}
+	const handleToggle = useCallback(
+		(tagId: string) => {
+			if (selectedIds.includes(tagId)) {
+				onChange(selectedIds.filter((id) => id !== tagId));
+			} else if (selectedIds.length < 10) {
+				onChange([...selectedIds, tagId]);
+			}
+		},
+		[selectedIds, onChange],
+	);
 
 	return (
 		<div className="space-y-4">
@@ -52,7 +50,6 @@ export function TagSelector({ tags, selectedIds, onChange, categories }: TagSele
 					categoryTags={categoryTags}
 					selectedIds={selectedIds}
 					onToggle={handleToggle}
-					onDropdownAdd={handleDropdownAdd}
 				/>
 			))}
 			<p className="text-xs text-muted-foreground">
@@ -67,7 +64,6 @@ interface CategoryTagGroupProps {
 	categoryTags: TagInfo[];
 	selectedIds: string[];
 	onToggle: (tagId: string) => void;
-	onDropdownAdd: (tagId: string) => void;
 }
 
 function CategoryTagGroup({
@@ -75,73 +71,141 @@ function CategoryTagGroup({
 	categoryTags,
 	selectedIds,
 	onToggle,
-	onDropdownAdd,
 }: CategoryTagGroupProps) {
-	const [dropdownValue, setDropdownValue] = useState('');
-	const useDropdown = categoryTags.length >= DROPDOWN_THRESHOLD;
-	const selectedInCategory = categoryTags.filter((t) => selectedIds.includes(t.id));
-	const unselectedInCategory = categoryTags.filter((t) => !selectedIds.includes(t.id));
+	const [isModalOpen, setIsModalOpen] = useState(false);
+	const hasMore = categoryTags.length > VISIBLE_COUNT;
+	const visibleTags = hasMore ? categoryTags.slice(0, VISIBLE_COUNT) : categoryTags;
+	const hiddenCount = categoryTags.length - VISIBLE_COUNT;
 
 	return (
 		<div>
 			<p className="text-xs font-medium text-muted-foreground mb-2">{categoryName}</p>
-			{useDropdown ? (
-				<div className="space-y-2">
-					{selectedInCategory.length > 0 && (
-						<div className="flex flex-wrap gap-2">
-							{selectedInCategory.map((tag) => (
-								<button
-									key={tag.id}
-									type="button"
-									onClick={() => onToggle(tag.id)}
-									aria-pressed={true}
-									className="rounded-md px-2.5 py-1 text-xs transition-colors bg-primary text-primary-foreground"
-								>
-									{tag.name} ✕
-								</button>
-							))}
-						</div>
-					)}
-					<select
-						value={dropdownValue}
-						onChange={(e) => {
-							onDropdownAdd(e.target.value);
-							setDropdownValue('');
-						}}
-						disabled={selectedIds.length >= 10}
-						className="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 outline-none disabled:opacity-50"
+			<div className="flex flex-wrap gap-2">
+				{visibleTags.map((tag) => (
+					<TagButton
+						key={tag.id}
+						tag={tag}
+						isSelected={selectedIds.includes(tag.id)}
+						disabled={!selectedIds.includes(tag.id) && selectedIds.length >= 10}
+						onToggle={onToggle}
+					/>
+				))}
+				{hasMore && (
+					<button
+						type="button"
+						onClick={() => setIsModalOpen(true)}
+						className="rounded-md px-2.5 py-1 text-xs transition-colors bg-secondary text-muted-foreground hover:bg-secondary/80 border border-dashed border-muted-foreground/30"
 					>
-						<option value="">タグを選択...</option>
-						{unselectedInCategory.map((tag) => (
-							<option key={tag.id} value={tag.id}>
-								{tag.name}
-							</option>
-						))}
-					</select>
-				</div>
-			) : (
-				<div className="flex flex-wrap gap-2">
-					{categoryTags.map((tag) => {
-						const isSelected = selectedIds.includes(tag.id);
-						return (
-							<button
-								key={tag.id}
-								type="button"
-								onClick={() => onToggle(tag.id)}
-								disabled={!isSelected && selectedIds.length >= 10}
-								aria-pressed={isSelected}
-								className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
-									isSelected
-										? 'bg-primary text-primary-foreground'
-										: 'bg-secondary text-muted-foreground hover:bg-secondary/80 disabled:opacity-50'
-								}`}
-							>
-								{tag.name}
-							</button>
-						);
-					})}
-				</div>
+						さらに表示（+{hiddenCount}）
+					</button>
+				)}
+			</div>
+			{isModalOpen && (
+				<TagModal
+					categoryName={categoryName}
+					categoryTags={categoryTags}
+					selectedIds={selectedIds}
+					onToggle={onToggle}
+					onClose={() => setIsModalOpen(false)}
+				/>
 			)}
+		</div>
+	);
+}
+
+interface TagButtonProps {
+	tag: TagInfo;
+	isSelected: boolean;
+	disabled: boolean;
+	onToggle: (tagId: string) => void;
+}
+
+function TagButton({ tag, isSelected, disabled, onToggle }: TagButtonProps) {
+	return (
+		<button
+			type="button"
+			onClick={() => onToggle(tag.id)}
+			disabled={disabled}
+			aria-pressed={isSelected}
+			className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
+				isSelected
+					? 'bg-primary text-primary-foreground'
+					: 'bg-secondary text-muted-foreground hover:bg-secondary/80 disabled:opacity-50'
+			}`}
+		>
+			{tag.name}
+		</button>
+	);
+}
+
+interface TagModalProps {
+	categoryName: string;
+	categoryTags: TagInfo[];
+	selectedIds: string[];
+	onToggle: (tagId: string) => void;
+	onClose: () => void;
+}
+
+function TagModal({ categoryName, categoryTags, selectedIds, onToggle, onClose }: TagModalProps) {
+	const overlayRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (e.key === 'Escape') onClose();
+		}
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [onClose]);
+
+	function handleOverlayClick(e: React.MouseEvent) {
+		if (e.target === overlayRef.current) onClose();
+	}
+
+	return (
+		<div
+			ref={overlayRef}
+			role="dialog"
+			aria-modal="true"
+			aria-label={`${categoryName}のタグを選択`}
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			onClick={handleOverlayClick}
+			onKeyDown={(e) => {
+				if (e.key === 'Escape') onClose();
+			}}
+		>
+			<div className="w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg mx-4">
+				<div className="flex items-center justify-between mb-4">
+					<h3 className="text-lg font-semibold">{categoryName}</h3>
+					<button
+						type="button"
+						onClick={onClose}
+						className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+						aria-label="閉じる"
+					>
+						<X className="h-5 w-5" />
+					</button>
+				</div>
+				<div className="flex flex-wrap gap-2 max-h-64 overflow-y-auto">
+					{categoryTags.map((tag) => (
+						<TagButton
+							key={tag.id}
+							tag={tag}
+							isSelected={selectedIds.includes(tag.id)}
+							disabled={!selectedIds.includes(tag.id) && selectedIds.length >= 10}
+							onToggle={onToggle}
+						/>
+					))}
+				</div>
+				<div className="flex justify-end mt-4">
+					<button
+						type="button"
+						onClick={onClose}
+						className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+					>
+						完了
+					</button>
+				</div>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- プルダウンUIを廃止し、各カテゴリの最初の5個をボタン表示
- 6個目以降は「さらに表示（+N）」ボタンからモーダルで全タグを選択可能に
- モーダル内でタグの選択・解除が可能、Escape/オーバーレイクリックで閉じる
- ボタン一覧の統一感を維持しつつ、タグ増加時もスッキリした表示に

Closes #171

## Test plan
- [ ] タグ5個以下のカテゴリでは従来通りボタン表示のみ
- [ ] タグ6個以上のカテゴリで「さらに表示（+N）」ボタンが表示される
- [ ] 「さらに表示」クリックでモーダルが開き、全タグが表示される
- [ ] モーダル内でタグの選択・解除ができる
- [ ] Escape キーやオーバーレイクリックでモーダルが閉じる
- [ ] 「完了」ボタンでモーダルが閉じる
- [ ] タグ上限10個の制限が引き続き機能する
- [ ] 記事編集ページでも同様に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)