### PR TITLE
fix: 記事詳細画面で散会図が見切れるバグを修正 (#175)

### DIFF
--- a/src/components/diagram/renderDiagramSvg.ts
+++ b/src/components/diagram/renderDiagramSvg.ts
@@ -92,7 +92,7 @@ function renderMarker(role: string, nx: number, ny: number): string {
 
 export function renderDiagramSvg(data: DiagramData): string {
 	const parts: string[] = [
-		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${SVG_SIZE} ${SVG_SIZE}" width="100%" height="100%">`,
+		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${SVG_SIZE} ${SVG_SIZE}" width="100%">`,
 		renderBackground(),
 		renderField(),
 		renderCrossLines(),

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -374,6 +374,7 @@
 .diagram-container {
 	max-width: 400px;
 	margin: 1.25rem auto;
+	aspect-ratio: 1 / 1;
 }
 .diagram-container svg {
 	width: 100%;


### PR DESCRIPTION
## Summary
- 記事詳細画面で散会図（diagram）の下半分が見切れて表示されるバグを修正
- SVG の `height="100%"` 属性を削除し、`viewBox` + `width` でアスペクト比を自然に維持
- `.diagram-container` に `aspect-ratio: 1 / 1` を追加して確実に正方形表示

Closes #175

## Test plan
- [ ] 散会図を含む記事の詳細画面で、散会図が正方形に全体表示されることを確認
- [ ] エディタのプレビューでも同様に表示されることを確認
- [ ] 異なる画面幅でレスポンシブに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)