### PR TITLE
fix: 散開図エディタでロールアイコンがはみ出る問題を修正 (#201)

### DIFF
--- a/src/components/diagram/DiagramEditor.tsx
+++ b/src/components/diagram/DiagramEditor.tsx
@@ -134,7 +134,7 @@ export function DiagramEditor({ initialData, onChange }: DiagramEditorProps) {
 					onDropWaymark={handleDropWaymark}
 				/>
 			</div>
-			<div className="flex-shrink-0">
+			<div className="min-w-0">
 				<DiagramPalette
 					existingMarkers={data.markers.map((m) => m.role)}
 					existingWaymarks={data.waymarks.map((w) => w.label)}


### PR DESCRIPTION
## Summary
- 散開図エディタのパレットコンテナに `flex-shrink-0` が設定されていたため、ロールアイコン（D3, D4）がモーダル右端からはみ出していた
- `flex-shrink-0` → `min-w-0` に変更し、flexbox の子要素が適切に縮小・折り返しされるように修正

Closes #201

## Test plan
- [ ] 散開図エディタを開き、ロールアイコン8個がモーダル内に収まっていることを確認
- [ ] ウェイマークアイコンも同様にはみ出していないことを確認
- [ ] ドラッグ＆ドロップでマーカー配置が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)