### PR TITLE
fix: 散開図SVGにwidth/height属性を追加して見切れを修正 (#200)

### DIFF
--- a/src/components/diagram/renderDiagramSvg.ts
+++ b/src/components/diagram/renderDiagramSvg.ts
@@ -92,7 +92,7 @@ function renderMarker(role: string, nx: number, ny: number): string {
 
 export function renderDiagramSvg(data: DiagramData): string {
 	const parts: string[] = [
-		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${SVG_SIZE} ${SVG_SIZE}">`,
+		`<svg xmlns="http://www.w3.org/2000/svg" width="${SVG_SIZE}" height="${SVG_SIZE}" viewBox="0 0 ${SVG_SIZE} ${SVG_SIZE}">`,
 		renderBackground(),
 		renderField(),
 		renderCrossLines(),


### PR DESCRIPTION
## Summary
- 散開図SVGに明示的な`width`/`height`属性を追加し、記事詳細画面で見切れる問題を修正
- `sanitize-html`が`viewBox`を`viewbox`に小文字化することでブラウザがアスペクト比を認識できなかった根本原因に対処

Closes #200

## Test plan
- [ ] 散開図を含む記事の詳細ページで、散開図が正方形で完全に表示されることを確認
- [ ] エディタ内のプレビューでも正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)