### PR TITLE
fix: タグセクションをエディタ本体の下に移動

### DIFF
--- a/src/components/editor/ArticleEditor.tsx
+++ b/src/components/editor/ArticleEditor.tsx
@@ -156,15 +156,6 @@ export function ArticleEditor({ mode, tags, categories, article }: ArticleEditor
 				<p className="text-xs text-muted-foreground text-right">{title.length}/100</p>
 			</div>
 
-			{/* Tags */}
-			<TagSelector
-				tags={tags}
-				selectedIds={selectedTags}
-				onChange={setSelectedTags}
-				categories={categories}
-			/>
-			{errors.tags && <p className="text-sm text-destructive">{errors.tags[0]}</p>}
-
 			{/* Patch */}
 			<div className="space-y-2">
 				<Label>パッチバージョン</Label>
@@ -326,6 +317,15 @@ export function ArticleEditor({ mode, tags, categories, article }: ArticleEditor
 					<ImageUploader onInsert={handleImageInsert} />
 				</div>
 			)}
+
+			{/* Tags */}
+			<TagSelector
+				tags={tags}
+				selectedIds={selectedTags}
+				onChange={setSelectedTags}
+				categories={categories}
+			/>
+			{errors.tags && <p className="text-sm text-destructive">{errors.tags[0]}</p>}
 
 			{showMacroDialogMd && (
 				<div


### PR DESCRIPTION
## Summary
- タグ選択セクションがエディタの上にあり、選択肢が多いとエディタ本体までのスクロールが長くなっていた問題を修正
- タグセクションをエディタ本文の下に移動し、記事執筆時のUXを改善

## Test plan
- [ ] 新規記事作成画面でタグセクションがエディタの下に表示されることを確認
- [ ] 記事編集画面でタグセクションがエディタの下に表示されることを確認
- [ ] タグの選択・解除が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)