### PR TITLE
fix: SP時に記事詳細の見出しとボタンを段落ちさせる (#207)

### DIFF
--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -84,7 +84,7 @@ const jsonLd = {
 <Layout title={article.title} description={description} jsonLd={jsonLd}>
 	<article class="py-8 max-w-3xl mx-auto">
 		<header class="mb-8">
-			<div class="flex items-start justify-between gap-4">
+			<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
 				<h1 class="text-3xl font-bold text-foreground sm:text-4xl leading-tight">
 					{article.title}
 				</h1>


### PR DESCRIPTION
## Summary
- SP表示時に記事詳細ページの見出し（h1）と編集/削除ボタンが横並びで見出しが圧縮される問題を修正
- `flex` → `flex flex-col sm:flex-row` に変更し、SP時はボタンが見出しの下に段落ちするように

Closes #207

## Test plan
- [ ] SP幅で長いタイトルの記事を表示し、ボタンが見出しの下に表示されることを確認
- [ ] PC幅では従来通り横並びレイアウトであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)