### PR TITLE
chore: CI にドキュメント変更時のスキップ設定を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'docs/**'
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- CI ワークフローに `paths-ignore` を追加
- `*.md`, `LICENSE`, `.gitignore`, `docs/**` のみの変更時は CI をスキップ
- `[skip ci]` のコミットメッセージによるスキップも引き続き利用可能

## Test plan
- [ ] ドキュメントのみの PR で CI がスキップされることを確認
- [ ] ソースコードを含む PR では通常通り CI が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)